### PR TITLE
make retry count and interval as configurable parameter

### DIFF
--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -71,9 +71,13 @@ The sample content of ovs.conf (in JSON format) is as follows:
 
 ```json
 {
-  "socket_file": "/usr/local/var/run/openvswitch/db.sock"
+  "socket_file": "/usr/local/var/run/openvswitch/db.sock",
+  "link_state_check_retries": 5,
+  "link_state_check_interval": 1000
 }
 ```
+
+The `link_state_check_interval` is in milliseconds.
 
 ## Manual Testing
 


### PR DESCRIPTION
In a large K8s cluster sometimes it takes a while for OF port to be up state, so
making retry count and interval as configurable parameter so that cni
can wait a bit longer until OF port to be up.

Fixes #159 

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>