### PR TITLE
use cached netconf to avoid delete loop

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright (c) 2021 CNI authors
+// Copyright (c) 2021 Nordix Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/imdario/mergo"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
+)
+
+const (
+	linkstateCheckRetries  = 5
+	linkStateCheckInterval = 600 // in milliseconds
+)
+
+// LoadConf parses and validates stdin netconf and returns NetConf object
+func LoadConf(data []byte) (*types.NetConf, error) {
+	netconf, err := loadNetConf(data)
+	if err != nil {
+		return nil, err
+	}
+	flatNetConf, err := loadFlatNetConf(netconf.ConfigurationPath)
+	if err != nil {
+		return nil, err
+	}
+	netconf, err = mergeConf(netconf, flatNetConf)
+	if err != nil {
+		return nil, err
+	}
+	if netconf.LinkStateCheckRetries == 0 {
+		netconf.LinkStateCheckRetries = linkstateCheckRetries
+	}
+
+	if netconf.LinkStateCheckInterval == 0 {
+		netconf.LinkStateCheckInterval = linkStateCheckInterval
+	}
+	return netconf, nil
+}
+
+// LoadConfFromCache retrieve net config from cache
+func LoadConfFromCache(cRef string) (*types.CachedNetConf, error) {
+	netCache := &types.CachedNetConf{}
+	netConfBytes, err := utils.ReadCache(cRef)
+	if err != nil {
+		return nil, fmt.Errorf("error reading cached NetConf with name %s: %v", cRef, err)
+	}
+
+	if err = json.Unmarshal(netConfBytes, netCache); err != nil {
+		return nil, fmt.Errorf("failed to parse NetConf: %v", err)
+	}
+
+	return netCache, nil
+}
+
+// GetCRef unique identifier for a container interface
+func GetCRef(cid, podIfName string) string {
+	return strings.Join([]string{cid, podIfName}, "-")
+}
+
+func loadNetConf(bytes []byte) (*types.NetConf, error) {
+	netconf := &types.NetConf{}
+	if err := json.Unmarshal(bytes, netconf); err != nil {
+		return nil, fmt.Errorf("failed to load netconf: %v", err)
+	}
+
+	return netconf, nil
+}
+
+func loadFlatNetConf(configPath string) (*types.NetConf, error) {
+	confFiles := getOvsConfFiles()
+	if configPath != "" {
+		confFiles = append([]string{configPath}, confFiles...)
+	}
+
+	// loop through the path and parse the JSON config
+	flatNetConf := &types.NetConf{}
+	for _, confFile := range confFiles {
+		confExists, err := pathExists(confFile)
+		if err != nil {
+			return nil, fmt.Errorf("error checking ovs config file: error: %v", err)
+		}
+		if confExists {
+			jsonFile, err := os.Open(confFile)
+			if err != nil {
+				return nil, fmt.Errorf("open ovs config file %s error: %v", confFile, err)
+			}
+			defer jsonFile.Close()
+			jsonBytes, err := ioutil.ReadAll(jsonFile)
+			if err != nil {
+				return nil, fmt.Errorf("load ovs config file %s: error: %v", confFile, err)
+			}
+			if err := json.Unmarshal(jsonBytes, flatNetConf); err != nil {
+				return nil, fmt.Errorf("parse ovs config file %s: error: %v", confFile, err)
+			}
+			break
+		}
+	}
+
+	return flatNetConf, nil
+}
+
+func mergeConf(netconf, flatNetConf *types.NetConf) (*types.NetConf, error) {
+	if err := mergo.Merge(netconf, flatNetConf); err != nil {
+		return nil, fmt.Errorf("merge with ovs config file: error: %v", err)
+	}
+	return netconf, nil
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func getOvsConfFiles() []string {
+	return []string{"/etc/kubernetes/cni/net.d/ovs.d/ovs.conf", "/etc/cni/net.d/ovs.d/ovs.conf"}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,8 +28,10 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -44,6 +46,7 @@ import (
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
 )
 
 const (
@@ -404,6 +407,11 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 	defer contNetns.Close()
 
+	// Cache NetConf for CmdDel
+	if err = utils.SaveConf(args.ContainerID, args.IfName, "netconf", netconf); err != nil {
+		return fmt.Errorf("error saving NetConf %q", err)
+	}
+
 	var hostIface, contIface *current.Interface
 	if netconf.DeviceID != "" {
 		// SR-IOV Case
@@ -554,6 +562,24 @@ func removeOvsPort(ovsDriver *ovsdb.OvsBridgeDriver, portName string) error {
 func CmdDel(args *skel.CmdArgs) error {
 	logCall("DEL", args)
 
+	netconf, cRefPath, err := loadConfFromCache(args)
+	if err != nil {
+		// If cmdDel() fails, cached netconf is cleaned up by
+		// the followed defer call. However, subsequence calls
+		// of cmdDel() from kubelet fail in a dead loop due to
+		// cached netconf doesn't exist.
+		// Return nil when LoadConfFromCache fails since the rest
+		// of cmdDel() code relies on netconf as input argument
+		// and there is no meaning to continue.
+		return nil
+	}
+
+	defer func() {
+		if err == nil && cRefPath != "" {
+			utils.CleanCachedConf(cRefPath)
+		}
+	}()
+
 	envArgs, err := getEnvArgs(args.Args)
 	if err != nil {
 		return err
@@ -564,11 +590,6 @@ func CmdDel(args *skel.CmdArgs) error {
 		ovnPort = string(envArgs.OvnPort)
 	}
 
-	netconf, err := loadAllNetConf(args.StdinData)
-	if err != nil {
-		return err
-	}
-
 	bridgeName, err := getBridgeName(netconf.BrName, ovnPort)
 	if err != nil {
 		return err
@@ -577,13 +598,6 @@ func CmdDel(args *skel.CmdArgs) error {
 	ovsDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, netconf.SocketFile)
 	if err != nil {
 		return err
-	}
-
-	if netconf.IPAM.Type != "" {
-		err = ipam.ExecDel(netconf.IPAM.Type, args.StdinData)
-		if err != nil {
-			return err
-		}
 	}
 
 	if args.Netns == "" {
@@ -648,6 +662,13 @@ func CmdDel(args *skel.CmdArgs) error {
 		})
 	}
 
+	if netconf.IPAM.Type != "" {
+		err = ipam.ExecDel(netconf.IPAM.Type, args.StdinData)
+		if err != nil {
+			return err
+		}
+	}
+
 	return err
 }
 
@@ -656,4 +677,23 @@ func CmdCheck(args *skel.CmdArgs) error {
 	logCall("CHECK", args)
 	log.Print("CHECK is not yet implemented, pretending everything is fine")
 	return nil
+}
+
+func loadConfFromCache(args *skel.CmdArgs) (*netConf, string, error) {
+	netConf := &netConf{}
+
+	s := []string{args.ContainerID, args.IfName, "netconf"}
+	cRef := strings.Join(s, "-")
+	cRefPath := filepath.Join(utils.DefaultCNIDir, cRef)
+
+	netConfBytes, err := utils.ReadScratchConf(cRefPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("error reading cached NetConf in %s with name %s", utils.DefaultCNIDir, cRef)
+	}
+
+	if err = json.Unmarshal(netConfBytes, netConf); err != nil {
+		return nil, "", fmt.Errorf("failed to parse NetConf: %q", err)
+	}
+
+	return netConf, cRefPath, nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -421,7 +421,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// Cache NetConf for CmdDel
-	if err = utils.SaveConf(args.ContainerID, args.IfName, &cachedNetConf{netconf, origIfName}); err != nil {
+	if err = utils.SaveCache(args.ContainerID, args.IfName, utils.DefaultCacheDir, &cachedNetConf{netconf, origIfName}); err != nil {
 		return fmt.Errorf("error saving NetConf %q", err)
 	}
 
@@ -589,7 +589,7 @@ func CmdDel(args *skel.CmdArgs) error {
 
 	defer func() {
 		if err == nil && cRefPath != "" {
-			utils.CleanCachedConf(cRefPath)
+			utils.CleanCache(cRefPath)
 		}
 	}()
 
@@ -697,11 +697,11 @@ func loadConfFromCache(args *skel.CmdArgs) (*cachedNetConf, string, error) {
 
 	s := []string{args.ContainerID, args.IfName}
 	cRef := strings.Join(s, "-")
-	cRefPath := filepath.Join(utils.DefaultCNIDir, cRef)
+	cRefPath := filepath.Join(utils.DefaultCacheDir, cRef)
 
-	netConfBytes, err := utils.ReadScratchConf(cRefPath)
+	netConfBytes, err := utils.ReadCache(cRefPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("error reading cached NetConf in %s with name %s", utils.DefaultCNIDir, cRef)
+		return nil, "", fmt.Errorf("error reading cached NetConf in %s with name %s", utils.DefaultCacheDir, cRef)
 	}
 
 	if err = json.Unmarshal(netConfBytes, netCache); err != nil {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/types"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -35,6 +35,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
 
 const bridgeName = "test-bridge"
@@ -70,7 +72,7 @@ var _ = Describe("CNI Plugin", func() {
 	})
 
 	testSplitVlanIds := func(conf string, expTrunks []uint, expErr error, setUnmarshalErr bool) {
-		var trunks []*trunk
+		var trunks []*types.Trunk
 		err := json.Unmarshal([]byte(conf), &trunks)
 		if setUnmarshalErr {
 			Expect(err).To(HaveOccurred())
@@ -556,7 +558,7 @@ func attach(namespace ns.NetNS, conf, ifName, mac, ovnPort string) *current.Resu
 	return result
 }
 
-func cmdAddWithArgs(args *skel.CmdArgs, f func() error) (types.Result, []byte, error) {
+func cmdAddWithArgs(args *skel.CmdArgs, f func() error) (cnitypes.Result, []byte, error) {
 	return testutils.CmdAdd(args.Netns, args.ContainerID, args.IfName, args.StdinData, f)
 }
 

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -60,6 +60,12 @@ func GetVFLinkName(pciAddr string) (string, error) {
 	return names[0], nil
 }
 
+// IsOvsHardwareOffloadEnabled when device id is set, then ovs hardware offload
+// is enabled.
+func IsOvsHardwareOffloadEnabled(deviceID string) bool {
+	return deviceID != ""
+}
+
 // GetNetRepresentor retrieves network representor device for smartvf
 func GetNetRepresentor(deviceID string) (string, error) {
 	// get Uplink netdevice.  The uplink is basically the PF name of the deviceID (smart VF).

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright (c) 2021 CNI authors
+// Copyright (c) 2021 Nordix Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/containernetworking/cni/pkg/types"
+
+// NetConf extends types.NetConf for ovs-cni
+type NetConf struct {
+	types.NetConf
+	BrName                 string   `json:"bridge,omitempty"`
+	VlanTag                *uint    `json:"vlan"`
+	MTU                    int      `json:"mtu"`
+	Trunk                  []*Trunk `json:"trunk,omitempty"`
+	DeviceID               string   `json:"deviceID"` // PCI address of a VF in valid sysfs format
+	ConfigurationPath      string   `json:"configuration_path"`
+	SocketFile             string   `json:"socket_file"`
+	LinkStateCheckRetries  int      `json:"link_state_check_retries"`
+	LinkStateCheckInterval int      `json:"link_state_check_interval"`
+}
+
+// Trunk containing selective vlan IDs
+type Trunk struct {
+	MinID *uint `json:"minID,omitempty"`
+	MaxID *uint `json:"maxID,omitempty"`
+	ID    *uint `json:"id,omitempty"`
+}
+
+// CachedNetConf containing NetConfig and original smartnic vf interface
+// name (set only in case of ovs hareware offload scenario).
+// this is intended to be used only for storing and retrieving config
+// to/from a data store (example file cache).
+type CachedNetConf struct {
+	Netconf    *NetConf
+	OrigIfName string
+}

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright (c) 2021 CNI authors
 // Copyright (c) 2021 Nordix Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Nordix Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Go version 1.10 or greater is required. Before that, switching namespaces in
+// long running processes in go did not work in a reliable way.
+// +build go1.10
+
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// DefaultCNIDir used for caching hostIFName
+	DefaultCNIDir = "/var/lib/cni/ovs"
+)
+
+// SaveConf takes in container ID, data dir and Pod interface name as string and a json encoded struct Conf
+// and save this Conf in data dir
+func SaveConf(cid, podIfName, prefix string, conf interface{}) error {
+	confBytes, err := json.Marshal(conf)
+	if err != nil {
+		return fmt.Errorf("error serializing delegate conf: %v", err)
+	}
+
+	s := []string{cid, podIfName, prefix}
+	cRef := strings.Join(s, "-")
+
+	// save the rendered conf for cmdDel
+	if err = saveScratchConf(cRef, DefaultCNIDir, confBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func saveScratchConf(containerID, dataDir string, conf []byte) error {
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return fmt.Errorf("failed to create the sriov data directory(%q): %v", dataDir, err)
+	}
+
+	path := filepath.Join(dataDir, containerID)
+
+	err := ioutil.WriteFile(path, conf, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write container data in the path(%q): %v", path, err)
+	}
+
+	return err
+}
+
+// ReadScratchConf read conf from disk and returns data in byte array
+func ReadScratchConf(cRefPath string) ([]byte, error) {
+	data, err := ioutil.ReadFile(cRefPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read container data in the path(%q): %v", cRefPath, err)
+	}
+	return data, err
+}
+
+// CleanCachedConf removed cached Conf from disk
+func CleanCachedConf(cRefPath string) error {
+	if err := os.Remove(cRefPath); err != nil {
+		return fmt.Errorf("error removing Conf file %s: %q", cRefPath, err)
+	}
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,13 +34,13 @@ var (
 
 // SaveConf takes in container ID, data dir and Pod interface name as string and a json encoded struct Conf
 // and save this Conf in data dir
-func SaveConf(cid, podIfName, prefix string, conf interface{}) error {
+func SaveConf(cid, podIfName string, conf interface{}) error {
 	confBytes, err := json.Marshal(conf)
 	if err != nil {
 		return fmt.Errorf("error serializing delegate conf: %v", err)
 	}
 
-	s := []string{cid, podIfName, prefix}
+	s := []string{cid, podIfName}
 	cRef := strings.Join(s, "-")
 
 	// save the rendered conf for cmdDel


### PR DESCRIPTION
Fixes #159 as this (OF Port not up error) causes infinite loop on the `CmdDel` invocation because of `DelNetwork: Error deallocating IP: Did not find reserved IP for container` error from CmdDel with whereabouts IPAM.

The fix is similar to approach used for [sriov-cni.](https://github.com/k8snetworkplumbingwg/sriov-cni/blob/master/cmd/sriov/main.go#L148-L172)

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>