### PR TITLE
docker, add virtual-tag docker-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 REGISTRY ?= quay.io/kubevirt
 IMAGE_TAG ?= latest
+IMAGE_GIT_TAG ?= $(shell git describe --abbrev=8 --tags)
 
 COMPONENTS = $(sort \
 			 $(subst /,-,\
@@ -71,6 +72,8 @@ docker-push: $(patsubst %, docker-push-%, $(COMPONENTS))
 
 docker-push-%:
 	docker push ${REGISTRY}/ovs-cni-$*:${IMAGE_TAG}
+	docker tag ${REGISTRY}/ovs-cni-$*:${IMAGE_TAG} ${REGISTRY}/ovs-cni-$*:${IMAGE_GIT_TAG}
+	docker push ${REGISTRY}/ovs-cni-$*:${IMAGE_GIT_TAG}
 
 dep: $(GO)
 	$(GO) mod tidy


### PR DESCRIPTION
currently, only tagged commits are docker build+pushed to Quay.
We also want to push regular main branch commits. 
This will allow us to run nightly tests in the future.

In order to do this, we add a docker-tag also non release commits.

