### PR TITLE
Fix a failure of plugin test

### DIFF
--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -137,7 +137,6 @@ ip netns del ns1
 This plugin also have Go test coverage. To run tests, Open vSwitch must be
 installed and its service running. Since those tests configure host networking,
 they must be executed by root.
-This also needs `host-local` ipam plugin to be present in one of the `PATH` directory.
 
 ```shell
 sudo --preserve-env make test-pkg-plugin


### PR DESCRIPTION
If the host-local plugin is not in the execution path, the test will fail as
follows. This PR fixes it by installing host-local plugin.

```
$ sudo make test-pkg-plugin
...
------------------------------
CNI Plugin connecting container to a bridge with specific IPAM set for container interface
  should successfully complete ADD and DEL commands
  /home/honma/git/ovs-cni/pkg/plugin/plugin_test.go:325
STEP: Creating temporary target namespace to simulate a container
STEP: Calling ADD command
2021/06/23 15:02:49 CNI ADD was called for container ID: dummy, network namespace /var/run/netns/cnitest-a058aa90-47f2-d394-fc73-f73d576db1c1, interface name eth0, configuration: {
				"cniVersion": "0.3.1",
				"name": "mynet",
				"type": "ovs",
				"bridge": "test-bridge",
				"ipam": {
					"type": "host-local",
					"ranges": [[ {"subnet": "10.1.2.0/24", "gateway": "10.1.2.1"} ]]
				}
			}

• Failure [0.312 seconds]
CNI Plugin
/home/honma/git/ovs-cni/pkg/plugin/plugin_test.go:56
  connecting container to a bridge
  /home/honma/git/ovs-cni/pkg/plugin/plugin_test.go:278
    with specific IPAM set for container interface
    /home/honma/git/ovs-cni/pkg/plugin/plugin_test.go:314
      should successfully complete ADD and DEL commands [It]
      /home/honma/git/ovs-cni/pkg/plugin/plugin_test.go:325

      Unexpected error:
          <*errors.errorString | 0xc000339710>: {
              s: "failed to set up IPAM plugin type \"host-local\": failed to find plugin \"host-local\" in path [/home/honma/git/ovs-cni/build/_output/bin//go//bin/ /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin]",
          }
          failed to set up IPAM plugin type "host-local": failed to find plugin "host-local" in path [/home/honma/git/ovs-cni/build/_output/bin//go//bin/ /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin]
      occurred

      /home/honma/git/ovs-cni/pkg/plugin/plugin_test.go:114
------------------------------
...
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>