### PR TITLE
clean up assigned ip address in ipam test

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -139,6 +139,12 @@ var _ = Describe("CNI Plugin", func() {
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
+
+		By("Calling DEL command to cleanup assigned ip address")
+		err = cmdDelWithArgs(args, func() error {
+			return CmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	testAddDel := func(conf string, setVlan, setMtu bool, Trunk string) {


### PR DESCRIPTION
invoke cmd del so that IP address would be cleaned from IPAM data backend. it would make subsequent test runs always pass on this test case. This may not be a problem in CI because tests are always run on a fresh system.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>