### PR TITLE
Modify data directory of host-local IPAM plugin

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -325,7 +325,8 @@ var _ = Describe("CNI Plugin", func() {
 				"bridge": "%s",
 				"ipam": {
 					"type": "host-local",
-					"ranges": [[ {"subnet": "10.1.2.0/24", "gateway": "10.1.2.1"} ]]
+					"ranges": [[ {"subnet": "10.1.2.0/24", "gateway": "10.1.2.1"} ]],
+					"dataDir": "/tmp/ovs-cni/conf"
 				}
 			}`, bridgeName)
 			It("should successfully complete ADD and DEL commands", func() {


### PR DESCRIPTION
The `host-local` IPAM plugin used to use `/var/lib/cni/networks/`, but has been moved under `/tmp` so as not to hurt the existing environment.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>