### PR TITLE
invoke ipam delete before net namespace check

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -494,6 +494,13 @@ func CmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if cache.Netconf.IPAM.Type != "" {
+		err = ipam.ExecDel(cache.Netconf.IPAM.Type, args.StdinData)
+		if err != nil {
+			return err
+		}
+	}
+
 	if args.Netns == "" {
 		// The CNI_NETNS parameter may be empty according to version 0.4.0
 		// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
@@ -533,13 +540,6 @@ func CmdDel(args *skel.CmdArgs) error {
 	// already removed by someone.
 	if portFound {
 		if err := removeOvsPort(ovsDriver, portName); err != nil {
-			return err
-		}
-	}
-
-	if cache.Netconf.IPAM.Type != "" {
-		err = ipam.ExecDel(cache.Netconf.IPAM.Type, args.StdinData)
-		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
moving `ipam.ExecDel `before `args.Netns == "" `check, this makes sure ip is cleaned up in pod delete retry scenario, because some cases args.Netns is passed with empty string.

found this issue while testing whereabouts [PR](https://github.com/k8snetworkplumbingwg/whereabouts/pull/119)

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>