### PR TITLE
tests, marker: increase timeout

### DIFF
--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -48,7 +48,7 @@ var _ = Describe("ovs-cni-marker", func() {
 					return false
 				}
 				return true
-			}, 120*time.Second, 5*time.Second).Should(Equal(true))
+			}, 180*time.Second, 5*time.Second).Should(Equal(true))
 
 			out, err = node.RunOnNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
 			if err != nil {
@@ -61,7 +61,7 @@ var _ = Describe("ovs-cni-marker", func() {
 				_, reported := node.Status.Capacity["ovs-cni.network.kubevirt.io/br-test"]
 				return reported
 
-			}, 120*time.Second, 5*time.Second).Should(Equal(false))
+			}, 180*time.Second, 5*time.Second).Should(Equal(false))
 		})
 	})
 })


### PR DESCRIPTION
The current timeout in the tests is 2 minutes. The update interval is 1 minute,
and it has a jitter of 1.2.
IF the test assertion start right after the start of the interval, 1 minute has passed ,
and for some reason the update fails, there could be more than two minutes between updates,
and the tests could fail.

This commit increases the tests timeout to 3 minutes, which should be enough.

Signed-off-by: alonsadan <asadan@redhat.com>