### PR TITLE
vendor, Bump to go.16 and fix vendor issue with ovn-org/libovsdb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.3
-	github.com/ovn-org/libovsdb v0.6.0
+	github.com/ovn-org/libovsdb v0.6.1-0.20210824154155-9cab5b210dce
 	github.com/pkg/errors v0.9.1
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1P
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/hub v1.0.1 h1:UMtjc6dHSaOQTO15SVA50MBIR9zQwvsukQupDrkIRtg=
 github.com/cenkalti/hub v1.0.1/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
-github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1 h1:aT9Ez2drLmrviqTnVnH87AeXLXLgUrXACJ2g90cTT2w=
-github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
+github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984 h1:CNwZyGS6KpfaOWbh2yLkSy3rSTUh3jub9CzpFpP6PVQ=
+github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -214,8 +214,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/ory/dockertest/v3 v3.7.0/go.mod h1:PvCCgnP7AfBZeVrzwiUTjZx/IUXlGLC1zQlUQrLIlUE=
-github.com/ovn-org/libovsdb v0.6.0 h1:/N4AU0QjIAe0vCLp99Mi82um6c4xh439pGFYEcZPUlQ=
-github.com/ovn-org/libovsdb v0.6.0/go.mod h1:5Ld4X+oWvMlbPAGvbJyE/wp8TAWdydI67jatQ3qbsVc=
+github.com/ovn-org/libovsdb v0.6.1-0.20210824154155-9cab5b210dce h1:G0ih8wuuqmap8Hj6+uQLw9UW0rMpc0Ib2dYUiqfjp9U=
+github.com/ovn-org/libovsdb v0.6.1-0.20210824154155-9cab5b210dce/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -123,7 +123,7 @@ func NewOvsBridgeDriver(bridgeName, socketFile string) (*OvsBridgeDriver, error)
 // Wrapper for ovsDB transaction
 func (ovsd *OvsDriver) ovsdbTransact(ops []ovsdb.Operation) ([]ovsdb.OperationResult, error) {
 	// Perform OVSDB transaction
-	reply, _ := ovsd.ovsClient.Transact(ops...)
+	reply, _ := ovsd.ovsClient.Transact(context.Background(), ops...)
 
 	if len(reply) < len(ops) {
 		return nil, errors.New("OVS transaction failed. Less replies than operations")

--- a/vendor/github.com/ovn-org/libovsdb/client/api.go
+++ b/vendor/github.com/ovn-org/libovsdb/client/api.go
@@ -11,13 +11,6 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
-const (
-	opInsert string = "insert"
-	opMutate string = "mutate"
-	opUpdate string = "insert"
-	opDelete string = "delete"
-)
-
 // API defines basic operations to interact with the database
 type API interface {
 	// List populates a slice of Models objects based on their type
@@ -264,7 +257,7 @@ func (a api) Create(models ...model.Model) ([]ovsdb.Operation, error) {
 		}
 
 		operations = append(operations, ovsdb.Operation{
-			Op:       opInsert,
+			Op:       ovsdb.OperationInsert,
 			Table:    tableName,
 			Row:      row,
 			UUIDName: namedUUID,
@@ -316,7 +309,7 @@ func (a api) Mutate(model model.Model, mutationObjs ...model.Mutation) ([]ovsdb.
 	for _, condition := range conditions {
 		operations = append(operations,
 			ovsdb.Operation{
-				Op:        opMutate,
+				Op:        ovsdb.OperationMutate,
 				Table:     tableName,
 				Mutations: mutations,
 				Where:     condition,
@@ -349,7 +342,7 @@ func (a api) Update(model model.Model, fields ...interface{}) ([]ovsdb.Operation
 	for _, condition := range conditions {
 		operations = append(operations,
 			ovsdb.Operation{
-				Op:    opUpdate,
+				Op:    ovsdb.OperationUpdate,
 				Table: table,
 				Row:   row,
 				Where: condition,
@@ -370,7 +363,7 @@ func (a api) Delete() ([]ovsdb.Operation, error) {
 	for _, condition := range conditions {
 		operations = append(operations,
 			ovsdb.Operation{
-				Op:    opDelete,
+				Op:    ovsdb.OperationDelete,
 				Table: a.cond.Table(),
 				Where: condition,
 			},

--- a/vendor/github.com/ovn-org/libovsdb/client/api_test_model.go
+++ b/vendor/github.com/ovn-org/libovsdb/client/api_test_model.go
@@ -131,21 +131,21 @@ func (*testLogicalSwitch) Table() string {
 //LogicalSwitchPort struct defines an object in Logical_Switch_Port table
 type testLogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
-	Up               []bool            `ovsdb:"up"`
-	Dhcpv4Options    []string          `ovsdb:"dhcpv4_options"`
+	Up               *bool             `ovsdb:"up"`
+	Dhcpv4Options    *string           `ovsdb:"dhcpv4_options"`
 	Name             string            `ovsdb:"name"`
-	DynamicAddresses []string          `ovsdb:"dynamic_addresses"`
-	HaChassisGroup   []string          `ovsdb:"ha_chassis_group"`
+	DynamicAddresses *string           `ovsdb:"dynamic_addresses"`
+	HaChassisGroup   *string           `ovsdb:"ha_chassis_group"`
 	Options          map[string]string `ovsdb:"options"`
-	Enabled          []bool            `ovsdb:"enabled"`
+	Enabled          *bool             `ovsdb:"enabled"`
 	Addresses        []string          `ovsdb:"addresses"`
-	Dhcpv6Options    []string          `ovsdb:"dhcpv6_options"`
-	TagRequest       []int             `ovsdb:"tag_request"`
-	Tag              []int             `ovsdb:"tag"`
+	Dhcpv6Options    *string           `ovsdb:"dhcpv6_options"`
+	TagRequest       *int              `ovsdb:"tag_request"`
+	Tag              *int              `ovsdb:"tag"`
 	PortSecurity     []string          `ovsdb:"port_security"`
 	ExternalIds      map[string]string `ovsdb:"external_ids"`
 	Type             string            `ovsdb:"type"`
-	ParentName       []string          `ovsdb:"parent_name"`
+	ParentName       *string           `ovsdb:"parent_name"`
 }
 
 // Table returns the table name. It's part of the Model interface

--- a/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -46,11 +46,11 @@ type Client interface {
 	SetOption(Option) error
 	Connected() bool
 	DisconnectNotify() chan struct{}
-	Echo() error
-	Transact(...ovsdb.Operation) ([]ovsdb.OperationResult, error)
-	Monitor(...TableMonitor) (string, error)
-	MonitorAll() (string, error)
-	MonitorCancel(id string) error
+	Echo(context.Context) error
+	Transact(context.Context, ...ovsdb.Operation) ([]ovsdb.OperationResult, error)
+	Monitor(context.Context, ...TableMonitor) (string, error)
+	MonitorAll(context.Context) (string, error)
+	MonitorCancel(ctx context.Context, id string) error
 	NewTableMonitor(m model.Model, fields ...interface{}) TableMonitor
 	API
 }
@@ -145,13 +145,15 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 		// FIXME: This only emits the error from the last attempted connection
 		return fmt.Errorf("failed to connect to endpoints %q: %v", o.options.endpoints, err)
 	}
+
 	if err := o.createRPC2Client(c); err != nil {
 		return err
 	}
 
-	dbs, err := o.listDbs()
+	dbs, err := o.listDbs(ctx)
 	if err != nil {
 		o.rpcClient.Close()
+		o.rpcClient = nil
 		return err
 	}
 
@@ -164,10 +166,11 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 	}
 	if !found {
 		o.rpcClient.Close()
+		o.rpcClient = nil
 		return fmt.Errorf("target database not found")
 	}
 
-	schema, err := o.getSchema(o.dbModel.Name())
+	schema, err := o.getSchema(ctx, o.dbModel.Name())
 	errors := o.dbModel.Validate(schema)
 	if len(errors) > 0 {
 		var combined []string
@@ -180,8 +183,10 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 
 	if err != nil {
 		o.rpcClient.Close()
+		o.rpcClient = nil
 		return err
 	}
+
 	o.schemaMutex.Lock()
 	o.schema = schema
 	o.schemaMutex.Unlock()
@@ -192,6 +197,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 			o.api = newAPI(o.cache)
 		} else {
 			o.rpcClient.Close()
+			o.rpcClient = nil
 			return err
 		}
 		o.cacheMutex.Unlock()
@@ -205,9 +211,10 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 		o.monitorsMutex.Lock()
 		defer o.monitorsMutex.Unlock()
 		for id, request := range o.monitors {
-			err = o.monitor(id, reconnect, request...)
+			err = o.monitor(ctx, id, reconnect, request...)
 			if err != nil {
 				o.rpcClient.Close()
+				o.rpcClient = nil
 				return err
 			}
 		}
@@ -312,10 +319,10 @@ func (o *ovsdbClient) update(args []json.RawMessage, reply *[]interface{}) error
 // getSchema returns the schema in use for the provided database name
 // RFC 7047 : get_schema
 // Should only be called when mutex is held
-func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
+func (o *ovsdbClient) getSchema(ctx context.Context, dbName string) (*ovsdb.DatabaseSchema, error) {
 	args := ovsdb.NewGetSchemaArgs(dbName)
 	var reply ovsdb.DatabaseSchema
-	err := o.rpcClient.Call("get_schema", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "get_schema", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return nil, ErrNotConnected
@@ -328,9 +335,9 @@ func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
 // listDbs returns the list of databases on the server
 // RFC 7047 : list_dbs
 // Should only be called when mutex is held
-func (o *ovsdbClient) listDbs() ([]string, error) {
+func (o *ovsdbClient) listDbs(ctx context.Context) ([]string, error) {
 	var dbs []string
-	err := o.rpcClient.Call("list_dbs", nil, &dbs)
+	err := o.rpcClient.CallWithContext(ctx, "list_dbs", nil, &dbs)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return nil, ErrNotConnected
@@ -342,7 +349,7 @@ func (o *ovsdbClient) listDbs() ([]string, error) {
 
 // Transact performs the provided Operations on the database
 // RFC 7047 : transact
-func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+func (o *ovsdbClient) Transact(ctx context.Context, operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
 	var reply []ovsdb.OperationResult
 	if ok := o.Schema().ValidateOperations(operation...); !ok {
 		return nil, fmt.Errorf("validation failed for the operation")
@@ -354,7 +361,7 @@ func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationR
 		o.rpcMutex.Unlock()
 		return nil, ErrNotConnected
 	}
-	err := o.rpcClient.Call("transact", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	o.rpcMutex.Unlock()
 	if err != nil {
 		if err == rpc2.ErrShutdown {
@@ -366,17 +373,17 @@ func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationR
 }
 
 // MonitorAll is a convenience method to monitor every table/column
-func (o *ovsdbClient) MonitorAll() (string, error) {
+func (o *ovsdbClient) MonitorAll(ctx context.Context) (string, error) {
 	var options []TableMonitor
 	for name := range o.dbModel.Types() {
 		options = append(options, TableMonitor{Table: name})
 	}
-	return o.Monitor(options...)
+	return o.Monitor(ctx, options...)
 }
 
 // MonitorCancel will request cancel a previously issued monitor request
 // RFC 7047 : monitor_cancel
-func (o *ovsdbClient) MonitorCancel(id string) error {
+func (o *ovsdbClient) MonitorCancel(ctx context.Context, id string) error {
 	var reply ovsdb.OperationResult
 	args := ovsdb.NewMonitorCancelArgs(id)
 	o.rpcMutex.Lock()
@@ -384,7 +391,7 @@ func (o *ovsdbClient) MonitorCancel(id string) error {
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	err := o.rpcClient.Call("monitor_cancel", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "monitor_cancel", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected
@@ -428,12 +435,12 @@ func (o *ovsdbClient) NewTableMonitor(m model.Model, fields ...interface{}) Tabl
 // and populate the cache with them. Subsequent updates will be processed
 // by the Update Notifications
 // RFC 7047 : monitor
-func (o *ovsdbClient) Monitor(options ...TableMonitor) (string, error) {
+func (o *ovsdbClient) Monitor(ctx context.Context, options ...TableMonitor) (string, error) {
 	id := uuid.NewString()
-	return id, o.monitor(id, false, options...)
+	return id, o.monitor(ctx, id, false, options...)
 }
 
-func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor) error {
+func (o *ovsdbClient) monitor(ctx context.Context, id string, reconnect bool, options ...TableMonitor) error {
 	if len(options) == 0 {
 		return fmt.Errorf("no monitor options provided")
 	}
@@ -463,7 +470,7 @@ func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	err := o.rpcClient.Call("monitor", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "monitor", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected
@@ -480,7 +487,7 @@ func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor
 }
 
 // Echo tests the liveness of the OVSDB connetion
-func (o *ovsdbClient) Echo() error {
+func (o *ovsdbClient) Echo(ctx context.Context) error {
 	args := ovsdb.NewEchoArgs()
 	var reply []interface{}
 	o.rpcMutex.RLock()
@@ -488,7 +495,7 @@ func (o *ovsdbClient) Echo() error {
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	err := o.rpcClient.Call("echo", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "echo", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected

--- a/vendor/github.com/ovn-org/libovsdb/ovsdb/bindings.go
+++ b/vendor/github.com/ovn-org/libovsdb/ovsdb/bindings.go
@@ -20,7 +20,7 @@ type ErrWrongType struct {
 }
 
 func (e *ErrWrongType) Error() string {
-	return fmt.Sprintf("Wrong Type (%s): expected %s but got %s (%s)",
+	return fmt.Sprintf("Wrong Type (%s): expected %s but got %+v (%s)",
 		e.from, e.expected, e.got, reflect.TypeOf(e.got))
 }
 
@@ -54,7 +54,7 @@ func NativeTypeFromAtomic(basicType string) reflect.Type {
 
 //NativeType returns the reflect.Type that can hold the value of a column
 //OVS Type to Native Type convertions:
-// OVS sets -> go slices
+// OVS sets -> go slices, arrays or a go native type depending on the key
 // OVS uuid -> go strings
 // OVS map  -> go map
 // OVS enum -> go native type depending on the type of the enum key
@@ -70,6 +70,18 @@ func NativeType(column *ColumnSchema) reflect.Type {
 		return reflect.MapOf(keyType, valueType)
 	case TypeSet:
 		keyType := NativeTypeFromAtomic(column.TypeObj.Key.Type)
+		// optional type
+		if column.TypeObj.Min() == 0 && column.TypeObj.Max() == 1 {
+			return reflect.PtrTo(keyType)
+		}
+		// non-optional type with max 1
+		if column.TypeObj.Min() == 1 && column.TypeObj.Max() == 1 {
+			return keyType
+		}
+		// max is > 1, use an array
+		if column.TypeObj.Max() > 1 {
+			return reflect.ArrayOf(column.TypeObj.Max(), keyType)
+		}
 		return reflect.SliceOf(keyType)
 	default:
 		panic(fmt.Errorf("unknown extended type %s", column.Type))
@@ -114,31 +126,77 @@ func OvsToNative(column *ColumnSchema, ovsElem interface{}) (interface{}, error)
 		naType := NativeType(column)
 		// The inner slice is []interface{}
 		// We need to convert it to the real type os slice
-		var nativeSet reflect.Value
-
-		// RFC says that for a set of exactly one, an atomic type an be sent
-		switch ovsSet := ovsElem.(type) {
-		case OvsSet:
-			nativeSet = reflect.MakeSlice(naType, 0, len(ovsSet.GoSet))
-			for _, v := range ovsSet.GoSet {
-				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+		switch naType.Kind() {
+		case reflect.Ptr:
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				if len(ovsSet.GoSet) > 1 {
+					return nil, fmt.Errorf("expected a slice of len =< 1, but got a slice with %d elements", len(ovsSet.GoSet))
+				}
+				if len(ovsSet.GoSet) == 0 {
+					return reflect.Zero(naType).Interface(), nil
+				}
+				native, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsSet.GoSet[0])
 				if err != nil {
 					return nil, err
 				}
+				pv := reflect.New(naType.Elem())
+				pv.Elem().Set(reflect.ValueOf(native))
+				return pv.Interface(), nil
+			default:
+				native, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+				pv := reflect.New(naType.Elem())
+				pv.Elem().Set(reflect.ValueOf(native))
+				return pv.Interface(), nil
+			}
+		case reflect.Array:
+			array := reflect.New(reflect.ArrayOf(column.TypeObj.Max(), naType.Elem())).Elem()
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				for i, v := range ovsSet.GoSet {
+					nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+					if err != nil {
+						return nil, err
+					}
+					array.Index(i).Set(reflect.ValueOf(nv))
+				}
+			default:
+				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+				array.Index(0).Set(reflect.ValueOf(nv))
+			}
+			return array.Interface(), nil
+		case reflect.Slice:
+			var nativeSet reflect.Value
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				nativeSet = reflect.MakeSlice(naType, 0, len(ovsSet.GoSet))
+				for _, v := range ovsSet.GoSet {
+					nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+					if err != nil {
+						return nil, err
+					}
+					nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
+				}
+
+			default:
+				nativeSet = reflect.MakeSlice(naType, 0, 1)
+				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+
 				nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
 			}
-
+			return nativeSet.Interface(), nil
 		default:
-			nativeSet = reflect.MakeSlice(naType, 0, 1)
-			nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
-			if err != nil {
-				return nil, err
-			}
-
-			nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
+			return nil, fmt.Errorf("native type was not slice, array or pointer. got %d", naType.Kind())
 		}
-		return nativeSet.Interface(), nil
-
 	case TypeMap:
 		naType := NativeType(column)
 		ovsMap, ok := ovsElem.(OvsMap)
@@ -196,9 +254,17 @@ func NativeToOvs(column *ColumnSchema, rawElem interface{}) (interface{}, error)
 		var ovsSet OvsSet
 		if column.TypeObj.Key.Type == TypeUUID {
 			var ovsSlice []interface{}
-			for _, v := range rawElem.([]string) {
-				uuid := UUID{GoUUID: v}
+			if _, ok := rawElem.([]string); ok {
+				for _, v := range rawElem.([]string) {
+					uuid := UUID{GoUUID: v}
+					ovsSlice = append(ovsSlice, uuid)
+				}
+			} else if _, ok := rawElem.(*string); ok {
+				v := rawElem.(*string)
+				uuid := UUID{GoUUID: *v}
 				ovsSlice = append(ovsSlice, uuid)
+			} else {
+				return nil, fmt.Errorf("uuid slice was neither []string or *string")
 			}
 			ovsSet = OvsSet{GoSet: ovsSlice}
 
@@ -354,11 +420,16 @@ func isDefaultBaseValue(elem interface{}, etype ExtendedType) bool {
 	if !value.IsValid() {
 		return true
 	}
-
+	if reflect.TypeOf(elem).Kind() == reflect.Ptr {
+		return reflect.ValueOf(elem).IsZero()
+	}
 	switch etype {
 	case TypeUUID:
 		return elem.(string) == "00000000-0000-0000-0000-000000000000" || elem.(string) == "" || isNamed(elem.(string))
 	case TypeMap, TypeSet:
+		if value.Kind() == reflect.Array {
+			return value.Len() == 0
+		}
 		return value.IsNil() || value.Len() == 0
 	case TypeString:
 		return elem.(string) == ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/Mellanox/sriovnet/pkg/utils/filesystem
 github.com/cenkalti/backoff/v4
 # github.com/cenkalti/hub v1.0.1
 github.com/cenkalti/hub
-# github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1
+# github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984
 github.com/cenkalti/rpc2
 github.com/cenkalti/rpc2/jsonrpc
 # github.com/containernetworking/cni v0.8.1 => github.com/containernetworking/cni v0.8.1
@@ -116,7 +116,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/ovn-org/libovsdb v0.6.0
+# github.com/ovn-org/libovsdb v0.6.1-0.20210824154155-9cab5b210dce
 ## explicit
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
Current go mod is getting an error on ovn-org/libovsdb
Issue was resolved [0] so pinned to current ovn-org/libovsdb main branch
Also bumped to go 1.16 which is needed for the veondoring to succeed

[0] ovn-org/libovsdb#217

Signed-off-by: Ram Lavi <ralavi@redhat.com>