### PR TITLE
Remove Go installation from automation/setup.sh

### DIFF
--- a/automation/setup.sh
+++ b/automation/setup.sh
@@ -1,24 +1,10 @@
-# Prepare environment for testing and automation. This includes temporary Go paths and binaries.
+# Prepare environment for testing and automation.
 #
 # source automation/setup.sh
 # cd ${TMP_PROJECT_PATH}
 
-echo 'Setup Go paths'
-export GOROOT=/tmp/ovs-cni/go/root
-mkdir -p $GOROOT
-export GOPATH=/tmp/ovs-cni/go/path
-mkdir -p $GOPATH
-export PATH=${GOPATH}/bin:${GOROOT}/bin:${PATH}
-
-echo 'Install Go 1.16'
-export GIMME_GO_VERSION=1.16
-GIMME=/tmp/ovs-cni/go/gimme
-mkdir -p $GIMME
-curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=${GIMME} bash >> ${GIMME}/gimme.sh
-source ${GIMME}/gimme.sh
-
-echo 'Install the project under the temporary Go path'
-TMP_PROJECT_PATH=${GOPATH}/src/github.com/k8snetworkplumbingwg/ovs-cni
+echo 'Copy the project under a temporary'
+TMP_PROJECT_PATH=/tmp/src/github.com/k8snetworkplumbingwg/ovs-cni
 rm -rf ${TMP_PROJECT_PATH}
 mkdir -p ${TMP_PROJECT_PATH}
 cp -rf $(pwd)/. ${TMP_PROJECT_PATH}


### PR DESCRIPTION
Go is now installed with the project, see $(GO) in Makefile. Therefore,
it is not needed to pre-install Golang in this CI specific script.

Signed-off-by: Petr Horáček <phoracek@redhat.com>