### PR TITLE
Download Go directly without gimme

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -3,11 +3,16 @@ FROM quay.io/fedora/fedora:32-x86_64
 RUN dnf -y install make git sudo gcc rsync-daemon rsync openvswitch hostname && \
     dnf -y clean all
 
-ENV GIMME_GO_VERSION=1.16
-
-RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
-
-ENV GOPATH="/go" GOBIN="/usr/bin"
+ENV GOPATH="/go"
+RUN \
+    DESTINATION=/opt && \
+    VERSION=1.16.7 && \
+    TARBALL=go${VERSION}.linux-amd64.tar.gz && \
+    URL=https://dl.google.com/go && \
+    mkdir -p ${DESTINATION} && \
+    curl -L ${URL}/${TARBALL} -o ${DESTINATION}/${TARBALL} && \
+    tar -xf ${DESTINATION}/${TARBALL} -C ${DESTINATION}
+ENV PATH="/opt/go/bin:$PATH"
 
 ADD rsyncd.conf /etc/rsyncd.conf
 
@@ -22,10 +27,7 @@ RUN \
     tar -xzf cni-plugins-linux-amd64-v0.8.5.tgz && \
     rm -f cni-plugins-linux-amd64-v0.8.5.tgz
 
-RUN \
-    mkdir -p /go && \
-    source /etc/profile.d/gimme.sh && \
-    go get -u github.com/onsi/ginkgo/ginkgo
+RUN go get -u github.com/onsi/ginkgo/ginkgo
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/hack/docker-builder/entrypoint.sh
+++ b/hack/docker-builder/entrypoint.sh
@@ -2,9 +2,6 @@
 set -e
 set -o pipefail
 
-source /etc/profile.d/gimme.sh
-export GOPATH="/root/go"
-
 # launch OVS
 function quit {
   /usr/share/openvswitch/scripts/ovs-ctl stop


### PR DESCRIPTION
Gimme started showing some issues downloading Go. Thus this PR replaces it by directly installing Go from the official website.

This should unblock https://github.com/k8snetworkplumbingwg/ovs-cni/pull/191

Signed-off-by: Petr Horáček <phoracek@redhat.com>