### PR TITLE
Bump Kubernetes to 1.20

### DIFF
--- a/automation/check-patch.e2e.sh
+++ b/automation/check-patch.e2e.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17'
+    export KUBEVIRT_PROVIDER='k8s-1.20'
 
     source automation/setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER='k8s-1.17'
+export KUBEVIRT_PROVIDER='k8s-1.20'
 
 KUBEVIRTCI_VERSION='8f48705333a7b9c4c91cf8a0b96b40bb54ef6c8d'
 export KUBEVIRTCI_TAG=2103111738-8f48705


### PR DESCRIPTION
The Kubernetes version 1.17 and 1.18 are already expired.
And 1.19 will reach to end of life soon.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

release-note
```release-note
Bump Kubernetes to 1.20
```