### PR TITLE
Bump Go to 1.16.8

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y install make git sudo gcc rsync-daemon rsync openvswitch hostname && 
 ENV GOPATH="/go"
 RUN \
     DESTINATION=/opt && \
-    VERSION=1.16.7 && \
+    VERSION=1.16.8 && \
     TARBALL=go${VERSION}.linux-amd64.tar.gz && \
     URL=https://dl.google.com/go && \
     mkdir -p ${DESTINATION} && \

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 destination=$1
-version=$(grep "^go " go.mod | awk '{print $2}')
+version=1.16.8
 tarball=go$version.linux-amd64.tar.gz
 url=https://dl.google.com/go/
 


### PR DESCRIPTION
Emmanuel recommends upgrading the Go language for security reason.
https://twitter.com/odeke_et/status/1436121362884542474

release-note
```release-note
Bump Go to 1.16.8
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>