### PR TITLE
derive container mac address from ip address

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -383,18 +383,20 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 
 		err = contNetns.Do(func(_ ns.NetNS) error {
-			for _, ipc := range newResult.IPs {
-				containerMac := IPAddrToHWAddr(ipc.Address.IP)
-				containerLink, err := netlink.LinkByName(args.IfName)
-				if err != nil {
-					return fmt.Errorf("failed to lookup container interface %q: %v", args.IfName, err)
+			if mac == "" && !sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+				for _, ipc := range newResult.IPs {
+					containerMac := IPAddrToHWAddr(ipc.Address.IP)
+					containerLink, err := netlink.LinkByName(args.IfName)
+					if err != nil {
+						return fmt.Errorf("failed to lookup container interface %q: %v", args.IfName, err)
+					}
+					err = assignMacToLink(containerLink, containerMac, args.IfName)
+					if err != nil {
+						return err
+					}
+					newResult.Interfaces[0].Mac = containerMac.String()
+					break
 				}
-				err = assignMacToLink(containerLink, containerMac, args.IfName)
-				if err != nil {
-					return err
-				}
-				newResult.Interfaces[0].Mac = containerMac.String()
-				break
 			}
 			err := ipam.ConfigureIface(args.IfName, newResult)
 			if err != nil {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -143,6 +143,7 @@ var _ = Describe("CNI Plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(addrs)).To(Equal(1))
 			Expect(addrs[0].String()).To(HavePrefix(ipPrefix))
+			Expect(link.Attrs().HardwareAddr).To(Equal(IPAddrToHWAddr(addrs[0].IP)))
 
 			if isDual {
 				addrs, err := netlink.AddrList(link, syscall.AF_INET6)


### PR DESCRIPTION
attempts to fix mac duplicates (because randomness of 3 suffix bytes not sufficient) in a big K8 cluster with many pods having secondary networks via ovs-cni.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>