### PR TITLE
Bump Kubernetes to 1.22

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER='k8s-1.20'
+export KUBEVIRT_PROVIDER='k8s-1.22'
 
-KUBEVIRTCI_VERSION='1a9626660867fe71046d0fa7bd4bfc2b3a5f3462'
-export KUBEVIRTCI_TAG=2109130756-1a96266
+KUBEVIRTCI_VERSION='3ff3b1ce03ef026bd633c7ec3668b87b8eecd70d'
+export KUBEVIRTCI_TAG=2109170950-3ff3b1c
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 
 function kubevirtci::install() {

--- a/examples/ovs-cni.yml
+++ b/examples/ovs-cni.yml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: ovs-cni-marker
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/manifests/ovs-cni.yml.in
+++ b/manifests/ovs-cni.yml.in
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: ovs-cni-marker
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
Also fix the caused warning.

```
Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/arch]: deprecated since v1.14; use "kubernetes.io/arch" instead
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>