### PR TITLE
Add nodeSelector for Linux os

### DIFF
--- a/manifests/ovs-cni.yml.in
+++ b/manifests/ovs-cni.yml.in
@@ -26,6 +26,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
In order to make sure that ovs-cni can be used
in mixed node environment I added Linux OS nodeSelector