### PR TITLE
Bump Kubernetes version of autotest

### DIFF
--- a/automation/check-patch.e2e.sh
+++ b/automation/check-patch.e2e.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.20'
+    export KUBEVIRT_PROVIDER='k8s-1.23'
 
     source automation/setup.sh
     cd ${TMP_PROJECT_PATH}


### PR DESCRIPTION
Bump `Kubernetes` version of autotest to 1.23.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>