### PR TITLE
ci: Bump kubevirtci an k8s to 1.23 (#221)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.8
 	github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
+	github.com/k8snetworkplumbingwg/ovs-cni v0.26.1
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/errors v0.9.1

--- a/tests/cmd/run.go
+++ b/tests/cmd/run.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+)
+
+// Run exec a command with its arguments and return stdout and stderr
+func Run(command string, arguments ...string) (string, error) {
+	cmd := exec.Command(command, arguments...)
+	ginkgo.GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n"))
+	var stdout, stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String())))
+	return stdout.String(), err
+}

--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -30,11 +30,11 @@ import (
 var _ = Describe("ovs-cni-marker", func() {
 	Describe("bridge resource reporting", func() {
 		It("should be reported only when available on node", func() {
-			out, err := node.RunOnNode("node01", "sudo ovs-vsctl add-br br-test")
+			out, err := node.RunAtNode("node01", "sudo ovs-vsctl add-br br-test")
 			if err != nil {
 				panic(fmt.Errorf("%v: %s", err, out))
 			}
-			defer node.RunOnNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
+			defer node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
 
 			Eventually(func() bool {
 				node, err := clusterApi.Clientset.CoreV1().Nodes().Get(context.TODO(), "node01", metav1.GetOptions{})
@@ -50,7 +50,7 @@ var _ = Describe("ovs-cni-marker", func() {
 				return true
 			}, 20*time.Second, 5*time.Second).Should(Equal(true))
 
-			out, err = node.RunOnNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
+			out, err = node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
 			if err != nil {
 				panic(fmt.Errorf("%v: %s", err, out))
 			}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -17,6 +17,7 @@ package tests_test
 
 import (
 	"flag"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -40,6 +41,9 @@ func TestPlugin(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	flag.Parse()
+
+	// Change to root directory some test expect that
+	os.Chdir("../")
 
 	clusterApi = clusterapi.NewClusterAPI(*kubeconfig)
 	clusterApi.RemoveTestNamespace()


### PR DESCRIPTION
Manual cherry-pick of #221 

The last kubevirtci does not work well with the functests at ovs-cni.
This change copy the ssh to node mechanism from kubernetes-nmstate that
is not to work fine, it also bump k8s to 1.23.

Signed-off-by: Quique Llorente <ellorent@redhat.com>