### PR TITLE
Bump kubevirtci

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG=2205030954-99bd4d1
+export KUBEVIRTCI_TAG=2207060141-111fd50
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
Take latest changes (that affect podman socket)
See https://github.com/kubevirt/kubevirt/pull/8048

In order to able to bump kubevirtci on CNAO, we need OVS to use the same version.
Since one of the lanes of CNAO clones OVS and uses the cluster-up folder of OVS
with the cluster created by CNAO.

```release-note
None
```