### PR TITLE
Replace deprecated go get with go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,7 @@ $(BASE): ; $(info  setting GOPATH...)
 
 GOLINT = $(GOBIN)/golint
 $(GOBIN)/golint: | $(BASE) ; $(info  building golint...)
-	$Q go get -u golang.org/x/lint/golint
-	# golint installation modifies go.mod and it causes golint failure so run mod tidy here
-	$(GO) mod tidy
+	$Q go install -mod=mod golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616
 
 build: format $(patsubst %, build-%, $(COMPONENTS))
 
@@ -66,7 +64,7 @@ build-host-local-plugin:
 	fi
 
 test: $(GO) build-host-local-plugin
-	$(GO) test ./cmd/... ./pkg/... -v --ginkgo.v
+	$(GO) test -mod=readonly ./cmd/... ./pkg/... -v --ginkgo.v
 
 docker-test:
 	hack/test-dockerized.sh

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     tar -xzf cni-plugins-linux-amd64-v1.0.1.tgz && \
     rm -f cni-plugins-linux-amd64-v1.0.1.tgz
 
-RUN go get -u github.com/onsi/ginkgo/ginkgo
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Without this, building of the containerized builder produces:

'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version,
like 'go install example.com/cmd@latest'
For more information, see https://golang.org/doc/go-get-install-deprecation
or run 'go help get' or 'go help install'.

Signed-off-by: Petr Horáček <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
