### PR TITLE
cleanup useless check in mirror test helper funcion 'CreateEmptyMirrors'

### DIFF
--- a/pkg/testhelpers/mirror.go
+++ b/pkg/testhelpers/mirror.go
@@ -238,10 +238,6 @@ func CreateEmptyMirrors(bridgeName string, mirrorNames []string, ovsPortOwner st
 			_, err = addOwnerToMirror(ovsPortOwner, mirrorName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
-		// check existence of the empty mirrors
-		emptyMirExists, err := IsMirrorExists(mirrorName)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(emptyMirExists).To(gomega.Equal(true))
 	}
 }
 

--- a/tests/mirror_test.go
+++ b/tests/mirror_test.go
@@ -94,7 +94,7 @@ var testMirrorFunc = func(version string) {
 						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("should be able to ping from pod '%s@%s' to pod '%s@%s'", podProd1Name, ipPodProd1.String(), podProd2Name, ipPodProd2.String()))
 
 						// wait a few seconds for the dump being written
-						time.Sleep(10 * time.Second)
+						time.Sleep(30 * time.Second)
 
 						tcpDumpResult, err := clusterApi.ReadFileFromPod(podConsName, "test", "/tcpdump.log")
 						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("should be able to read 'tcdump' log file from pod '%s'", podConsName))


### PR DESCRIPTION
Quick cleanup of mirror testhelper function as requested here https://github.com/k8snetworkplumbingwg/ovs-cni/pull/227#discussion_r979462642

If createEmptyMirror executed without an error, it's safe to assume that mirror is really in ovsdb Mirror table.