### PR TITLE
Provides a possible way to set interface's type of port.

### DIFF
--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -35,6 +35,17 @@ Another example with a trunk port and jumbo frames:
 }
 ```
 
+Another example with a port which has an interface of type afxdp:
+
+```json
+{
+   "name": "overlaynet",
+   "type": "ovs",
+   "bridge": "mynet1",
+   "interface_type": "afxdp"
+}
+```
+
 ## Network Configuration Reference
 
 * `name` (string, required): the name of the network.
@@ -46,6 +57,7 @@ Another example with a trunk port and jumbo frames:
 * `trunk` (optional): List of VLAN ID's and/or ranges of accepted VLAN
   ID's.
 * `ofport_request` (integer, optional): request a static OpenFlow port number in range 1 to 65,279
+* `interface_type` (string, optional): type of the interface belongs to ports. if value is "", ovs will use default interface of type 'internal'
 * `configuration_path` (optional): configuration file containing ovsdb
   socket file path, etc.
 

--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -150,8 +150,8 @@ func (ovsd *OvsDriver) ovsdbTransact(ops []ovsdb.Operation) ([]ovsdb.OperationRe
 // **************** OVS driver API ********************
 
 // CreatePort Create an internal port in OVS
-func (ovsd *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string) error {
-	intfUUID, intfOp, err := createInterfaceOperation(intfName, ofportRequest, ovnPortName)
+func (ovsd *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string) error {
+	intfUUID, intfOp, err := createInterfaceOperation(intfName, ofportRequest, ovnPortName, intfType)
 	if err != nil {
 		return err
 	}
@@ -782,12 +782,17 @@ func (ovsd *OvsDriver) isMirrorExistsByConditions(conditions []ovsdb.Condition) 
 	return true, nil
 }
 
-func createInterfaceOperation(intfName string, ofportRequest uint, ovnPortName string) (ovsdb.UUID, *ovsdb.Operation, error) {
+func createInterfaceOperation(intfName string, ofportRequest uint, ovnPortName string, intfType string) (ovsdb.UUID, *ovsdb.Operation, error) {
 	intfUUIDStr := fmt.Sprintf("Intf%s", intfName)
 	intfUUID := ovsdb.UUID{GoUUID: intfUUIDStr}
 
 	intf := make(map[string]interface{})
 	intf["name"] = intfName
+
+	// Configure interface type if not nil
+	if intfType != "" {
+		intf["type"] = intfType
+	}
 
 	// Configure interface ID for ovn
 	if ovnPortName != "" {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -154,8 +154,8 @@ func getBridgeName(bridgeName, ovnPort string) (string, error) {
 	return "", fmt.Errorf("failed to get bridge name")
 }
 
-func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, contNetnsPath string, ovnPortName string) error {
-	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType)
+func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contNetnsPath string, ovnPortName string) error {
+	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType, intfType)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	if err = attachIfaceToBridge(ovsDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, vlanTagNum, trunks, portType, args.Netns, ovnPort); err != nil {
+	if err = attachIfaceToBridge(ovsDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, vlanTagNum, trunks, portType, netconf.InterfaceType, args.Netns, ovnPort); err != nil {
 		return err
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,7 @@ type NetConf struct {
 	Trunk                  []*Trunk `json:"trunk,omitempty"`
 	DeviceID               string   `json:"deviceID"`       // PCI address of a VF in valid sysfs format
 	OfportRequest          uint     `json:"ofport_request"` // OpenFlow port number in range 1 to 65,279
+	InterfaceType          string   `json:"interface_type"` // The type of interface on ovs.
 	ConfigurationPath      string   `json:"configuration_path"`
 	SocketFile             string   `json:"socket_file"`
 	LinkStateCheckRetries  int      `json:"link_state_check_retries"`


### PR DESCRIPTION
  In the current code, only the 'internal' type which is also the defaut type of interface is available when ovs-cni create one interface for port.

  This commit added extra content to provides a possible way of setting interface's type when cni call func 'attachIfaceToBridge', In order to accommodate this function, also expanded type NetConf for ovs-cni and added extra arguments to function 'attachIfaceToBridge'.

  This will allow the user to select a custom type of interface when creating a port on bridge.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
