### PR TITLE
[release-0.29] Increase timeout of mirror tests (#255)

### DIFF
--- a/tests/mirror_test.go
+++ b/tests/mirror_test.go
@@ -78,7 +78,7 @@ var testMirrorFunc = func(version string) {
 						Eventually(func() error {
 							_, err := clusterApi.ReadFileFromPod(podConsName, "test", "/tcpdump.log")
 							return err
-						}, 30 * time.Second, time.Second).Should(Succeed(), "tcpdump did not start in time");
+						}, 120 * time.Second, time.Second).Should(Succeed(), "tcpdump did not start in time");
 
 						clusterApi.CreatePrivilegedPodWithIP(podProd1Name, nadProducerName, bridgeName, cidrPodProd1, "")
 						clusterApi.CreatePrivilegedPodWithIP(podProd2Name, nadProducerName, bridgeName, cidrPodProd2, "")


### PR DESCRIPTION
**What this PR does / why we need it**:

30 seconds is not enough on slower systems.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
