### PR TITLE
Golangci lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,14 @@ $(BASE): ; $(info  setting GOPATH...)
 	@mkdir -p $(dir $@)
 	@ln -sf $(CURDIR) $@
 
-GOLINT = $(GOBIN)/golint
-$(GOBIN)/golint: | $(BASE) ; $(info  building golint...)
-	$Q go install -mod=mod golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616
+GOLANGCI = $(GOBIN)/golangci-lint
+$(GOBIN)/golangci-lint: | $(BASE) ; $(info  building golangci-lint...)
+	$Q go install -mod=mod github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 build: format $(patsubst %, build-%, $(COMPONENTS))
 
-lint: | $(GO) $(BASE) $(GOLINT) ; $(info  running golint...) @ ## Run golint
-	$Q cd $(BASE) && ret=0 && for pkg in $(PKGS); do \
-		test -z "$$($(GOLINT) $$pkg | tee /dev/stderr)" || ret=1 ; \
-	 done ; exit $$ret
+lint: $(GO) $(GOLANGCI)
+	$(GOLANGCI) run
 
 build-%: $(GO)
 	cd cmd/$* && $(GO) fmt && $(GO) vet && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on $(GO) build -tags no_openssl -mod vendor

--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -95,7 +95,7 @@ func main() {
 	markerCache := cache.Cache{}
 	wait.JitterUntil(func() {
 		jitteredReconcileInterval := wait.Jitter(time.Duration(*reconcileInterval)*time.Minute, 1.2)
-		shouldReconcileNode := time.Now().Sub(markerCache.LastRefreshTime()) >= jitteredReconcileInterval
+		shouldReconcileNode := time.Since(markerCache.LastRefreshTime()) >= jitteredReconcileInterval
 		if shouldReconcileNode {
 			reportedBridges, err := markerApp.GetReportedResources()
 			if err != nil {

--- a/pkg/mirror-consumer/consumer.go
+++ b/pkg/mirror-consumer/consumer.go
@@ -154,7 +154,9 @@ func CmdDel(args *skel.CmdArgs) error {
 
 	defer func() {
 		if err == nil {
-			utils.CleanCache(cRef + "_cons")
+			if err := utils.CleanCache(cRef + "_cons"); err != nil {
+				log.Printf("Failed cleaning up cache: %v", err)
+			}
 		}
 	}()
 

--- a/pkg/mirror-consumer/consumer_test.go
+++ b/pkg/mirror-consumer/consumer_test.go
@@ -51,7 +51,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	output, err := exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).CombinedOutput()
+	output, err := exec.Command("ovs-vsctl", "--if-exists", "del-br", bridgeName).CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), "Cleanup of the bridge failed: %v", string(output[:]))
 })
 

--- a/pkg/mirror-consumer/consumer_test.go
+++ b/pkg/mirror-consumer/consumer_test.go
@@ -51,7 +51,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).Run()
+	output, err := exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "Cleanup of the bridge failed: %v", string(output[:]))
 })
 
 var _ = Describe("CNI mirror-consumer 0.3.0", func() { testFunc("0.3.0") })
@@ -399,7 +400,8 @@ var testFunc = func(version string) {
 				By("create a producer interface and add its port via 'ovs-vsctl' to fill both 'select_src_port' and 'select_dst_port'")
 				r2 := createInterfaces(IFNAME2, targetNs)
 				portUUID := GetPortUUIDFromResult(r2)
-				AddSelectPortToMirror(portUUID, mirrors[0].Name, true, true)
+				_, err = AddSelectPortToMirror(portUUID, mirrors[0].Name, true, true)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("run DEL command of ovs-mirror-consumer")
 				testDel(confMirror, mirrors, result, IFNAME1, targetNs)
@@ -466,9 +468,11 @@ var testFunc = func(version string) {
 				r2 := createInterfaces(IFNAME2, targetNs)
 				portUUID := GetPortUUIDFromResult(r2)
 				By(fmt.Sprintf("update mirror %s adding portUUID as 'select_src_port'", mirrors[0].Name))
-				AddSelectPortToMirror(portUUID, mirrors[0].Name, true, false)
+				_, err = AddSelectPortToMirror(portUUID, mirrors[0].Name, true, false)
+				Expect(err).NotTo(HaveOccurred())
 				By(fmt.Sprintf("update mirror %s adding portUUID as 'select_dst_port'", mirrors[1].Name))
-				AddSelectPortToMirror(portUUID, mirrors[1].Name, false, true)
+				_, err = AddSelectPortToMirror(portUUID, mirrors[1].Name, false, true)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("run DEL command of ovs-mirror-consumer")
 				testDel(confMirror, mirrors, result, IFNAME1, targetNs)

--- a/pkg/mirror-producer/producer.go
+++ b/pkg/mirror-producer/producer.go
@@ -146,7 +146,9 @@ func CmdDel(args *skel.CmdArgs) error {
 
 	defer func() {
 		if err == nil {
-			utils.CleanCache(cRef + "_prod")
+			if err := utils.CleanCache(cRef + "_prod"); err != nil {
+				log.Printf("Failed cleaning up cache: %v", err)
+			}
 		}
 	}()
 

--- a/pkg/mirror-producer/producer_test.go
+++ b/pkg/mirror-producer/producer_test.go
@@ -51,7 +51,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).Run()
+	output, err := exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "Cleanup of the bridge failed: %v", string(output[:]))
 })
 
 var _ = Describe("CNI mirror-producer 0.3.0", func() { testFunc("0.3.0") })
@@ -594,7 +595,8 @@ var testFunc = func(version string) {
 				By("create a consumer interface and add its port via 'ovs-vsctl' to fill mirror 'output_port'")
 				r2 := createInterfaces(IFNAME2, targetNs)
 				portUUID := GetPortUUIDFromResult(r2)
-				AddOutputPortToMirror(portUUID, mirrors[0].Name)
+				_, err = AddOutputPortToMirror(portUUID, mirrors[0].Name)
+				Expect(err).NotTo(HaveOccurred())
 
 				By("run DEL command of ovs-mirror-producer")
 				testDel(confMirror, mirrors, result, IFNAME1, targetNs)

--- a/pkg/mirror-producer/producer_test.go
+++ b/pkg/mirror-producer/producer_test.go
@@ -51,7 +51,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	output, err := exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).CombinedOutput()
+	output, err := exec.Command("ovs-vsctl", "--if-exists", "del-br", bridgeName).CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), "Cleanup of the bridge failed: %v", string(output[:]))
 })
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	output, err := exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).CombinedOutput()
+	output, err := exec.Command("ovs-vsctl", "--if-exists", "del-br", bridgeName).CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), "Cleanup of the bridge failed: %v", string(output[:]))
 })
 

--- a/tests/cluster/cluster.go
+++ b/tests/cluster/cluster.go
@@ -118,7 +118,7 @@ func (api *ClusterAPI) CreatePrivilegedPodWithIP(podName, nadName, bridgeName, c
 
 		if len(pod.Status.ContainerStatuses) > 0 {
 			for _, containerStatus := range pod.Status.ContainerStatuses {
-				if containerStatus.Ready != true {
+				if !containerStatus.Ready {
 					return false
 				}
 			}

--- a/tests/cmd/run.go
+++ b/tests/cmd/run.go
@@ -29,11 +29,21 @@ import (
 // Run exec a command with its arguments and return stdout and stderr
 func Run(command string, arguments ...string) (string, error) {
 	cmd := exec.Command(command, arguments...)
-	ginkgo.GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n"))
+
+	if _, err := ginkgo.GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n")); err != nil {
+		return "", err
+	}
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
-	err := cmd.Run()
-	ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String())))
-	return stdout.String(), err
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	if _, err := ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String()))); err != nil {
+		return "", err
+	}
+
+	return stdout.String(), nil
 }

--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -34,7 +34,12 @@ var _ = Describe("ovs-cni-marker", func() {
 			if err != nil {
 				panic(fmt.Errorf("%v: %s", err, out))
 			}
-			defer node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
+			defer func() {
+				_, err = node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
+				if err != nil {
+					panic(fmt.Errorf("%v: %s", err, out))
+				}
+			}()
 
 			Eventually(func() bool {
 				node, err := clusterApi.Clientset.CoreV1().Nodes().Get(context.TODO(), "node01", metav1.GetOptions{})
@@ -44,10 +49,7 @@ var _ = Describe("ovs-cni-marker", func() {
 					return false
 				}
 				capacityInt, _ := capacity.AsInt64()
-				if capacityInt != int64(1000) {
-					return false
-				}
-				return true
+				return capacityInt == int64(1000)
 			}, 180*time.Second, 5*time.Second).Should(Equal(true))
 
 			out, err = node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")

--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -16,7 +16,6 @@ package tests_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -31,14 +30,10 @@ var _ = Describe("ovs-cni-marker", func() {
 	Describe("bridge resource reporting", func() {
 		It("should be reported only when available on node", func() {
 			out, err := node.RunAtNode("node01", "sudo ovs-vsctl add-br br-test")
-			if err != nil {
-				panic(fmt.Errorf("%v: %s", err, out))
-			}
+			Expect(err).NotTo(HaveOccurred(), "Failed creating a test bridge: %v: %v", err, out)
 			defer func() {
-				_, err = node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
-				if err != nil {
-					panic(fmt.Errorf("%v: %s", err, out))
-				}
+				out, err = node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
+				Expect(err).NotTo(HaveOccurred(), "Failed cleaning up a test bridge: %v: %v", err, out)
 			}()
 
 			Eventually(func() bool {
@@ -53,9 +48,7 @@ var _ = Describe("ovs-cni-marker", func() {
 			}, 180*time.Second, 5*time.Second).Should(Equal(true))
 
 			out, err = node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
-			if err != nil {
-				panic(fmt.Errorf("%v: %s", err, out))
-			}
+			Expect(err).NotTo(HaveOccurred(), "Failed removing a test bridge: %v: %v", err, out)
 
 			Eventually(func() bool {
 				node, err := clusterApi.Clientset.CoreV1().Nodes().Get(context.TODO(), "node01", metav1.GetOptions{})

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -43,7 +43,8 @@ var _ = BeforeSuite(func() {
 	flag.Parse()
 
 	// Change to root directory some test expect that
-	os.Chdir("../")
+	err := os.Chdir("../")
+	Expect(err).NotTo(HaveOccurred())
 
 	clusterApi = clusterapi.NewClusterAPI(*kubeconfig)
 	clusterApi.RemoveTestNamespace()


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

The existing linter is not catching issues with unhandled errors etc. Golang-lint will check that and more, and will help us keep the codebase a little safer (and maybe even little prettier).

An  example of its output:

```
tests/cmd/run.go:32:27: Error return value of `ginkgo.GinkgoWriter.Write` is not checked (errcheck)
        ginkgo.GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n"))
                                 ^
tests/cmd/run.go:37:27: Error return value of `ginkgo.GinkgoWriter.Write` is not checked (errcheck)
        ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String())))
                                 ^
pkg/plugin/plugin.go:323:17: Error return value of `ipam.ExecDel` is not checked (errcheck)
                                ipam.ExecDel(netconf.IPAM.Type, args.StdinData)
                                            ^
pkg/plugin/plugin.go:473:20: Error return value of `utils.CleanCache` is not checked (errcheck)
                        utils.CleanCache(cRef)
                                        ^
pkg/plugin/plugin.go:551:17: Error return value of `sriov.ResetVF` is not checked (errcheck)
                        sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName)
                                     ^
pkg/plugin/plugin.go:562:21: Error return value of `ip.DelLinkByName` is not checked (errcheck)
                                ip.DelLinkByName(portName)
                                                ^
pkg/plugin/plugin_test.go:102:68: Error return value of `(*os/exec.Cmd).Run` is not checked (errcheck)
        exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).Run()
                                                                          ^
pkg/plugin/plugin_test.go:558:25: Error return value of `testutils.UnmountNS` is not checked (errcheck)
                                        testutils.UnmountNS(targetNs)
                                                           ^
pkg/mirror-producer/producer.go:149:20: Error return value of `utils.CleanCache` is not checked (errcheck)
                        utils.CleanCache(cRef + "_prod")
                                        ^
pkg/mirror-producer/producer_test.go:54:68: Error return value of `(*os/exec.Cmd).Run` is not checked (errcheck)
        exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).Run()
                                                                          ^
pkg/mirror-producer/producer_test.go:597:26: Error return value is not checked (errcheck)
                                AddOutputPortToMirror(portUUID, mirrors[0].Name)
                                                     ^
pkg/mirror-consumer/consumer.go:157:20: Error return value of `utils.CleanCache` is not checked (errcheck)
                        utils.CleanCache(cRef + "_cons")
                                        ^
pkg/mirror-consumer/consumer_test.go:54:68: Error return value of `(*os/exec.Cmd).Run` is not checked (errcheck)
        exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).Run()
                                                                          ^
pkg/mirror-consumer/consumer_test.go:402:26: Error return value is not checked (errcheck)
                                AddSelectPortToMirror(portUUID, mirrors[0].Name, true, true)
                                                     ^
pkg/mirror-consumer/consumer_test.go:469:26: Error return value is not checked (errcheck)
                                AddSelectPortToMirror(portUUID, mirrors[0].Name, true, false)
                                                     ^
tests/marker_test.go:37:24: Error return value of `node.RunAtNode` is not checked (errcheck)
                        defer node.RunAtNode("node01", "sudo ovs-vsctl --if-exists del-br br-test")
                                            ^
tests/tests_suite_test.go:46:10: Error return value of `os.Chdir` is not checked (errcheck)
        os.Chdir("../")
                ^
pkg/plugin/plugin.go:50:7: const `macSetupRetries` is unused (unused)
const macSetupRetries = 2
      ^
tests/marker_test.go:47:5: S1008: should use 'return capacityInt == int64(1000)' instead of 'if capacityInt != int64(1000) { return false }; return true' (gosimple)
                                if capacityInt != int64(1000) {
                                ^
pkg/plugin/plugin_test.go:814:2: S1017: should replace this if statement with an unconditional strings.TrimSuffix (gosimple)
        if strings.HasSuffix(extraArgs, ",") {
        ^
cmd/marker/main.go:98:26: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
                shouldReconcileNode := time.Now().Sub(markerCache.LastRefreshTime()) >= jitteredReconcileInterval
                                       ^
tests/cluster/cluster.go:121:8: S1002: should omit comparison to bool constant, can be simplified to `!containerStatus.Ready` (gosimple)
                                if containerStatus.Ready != true {
                                   ^
pkg/plugin/plugin.go:205:7: ineffectual assignment to id (ineffassign)
                var id uint = 0
                    ^
pkg/plugin/plugin.go:187:7: SA4003: no value of type `uint` is less than `0` (staticcheck)
                        if minID < 0 || minID > 4096 {
                           ^
pkg/plugin/plugin.go:193:7: SA4003: no value of type `uint` is less than `0` (staticcheck)
                        if maxID < 0 || maxID > 4096 {
                           ^
pkg/plugin/plugin.go:208:7: SA4003: no value of type `uint` is less than `0` (staticcheck)
                        if id < 0 || minID > 4096 {
                           ^

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
