### PR TITLE
Plumbing to optionally build for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ export GOROOT=$(BIN_DIR)/go/
 export GOBIN = $(GOROOT)/bin/
 export PATH := $(GOBIN):$(PATH):$(BIN_DIR)
 GOPATH = $(CURDIR)/.gopath
+GOARCH ?= amd64
 ORG_PATH = github.com/k8snetworkplumbingwg
 PACKAGE = ovs-cni
 OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
@@ -44,7 +45,7 @@ lint: $(GO) $(GOLANGCI)
 	$(GOLANGCI) run
 
 build-%: $(GO)
-	cd cmd/$* && $(GO) fmt && $(GO) vet && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on $(GO) build -tags no_openssl -mod vendor
+	cd cmd/$* && $(GO) fmt && $(GO) vet && GOOS=linux GOARCH=$(GOARCH) CGO_ENABLED=0 GO111MODULE=on $(GO) build -tags no_openssl -mod vendor
 
 format: $(GO)
 	$(GO) fmt ./pkg/... ./cmd/...
@@ -74,7 +75,7 @@ functest: $(GO)
 
 docker-build:
 	hack/get_version.sh > .version
-	$(OCI_BIN) build -t ${REGISTRY}/ovs-cni-plugin:${IMAGE_TAG} -f ./cmd/Dockerfile .
+	$(OCI_BIN) build --build-arg goarch=${GOARCH} -t ${REGISTRY}/ovs-cni-plugin:${IMAGE_TAG} -f ./cmd/Dockerfile .
 
 docker-push:
 	$(OCI_BIN) push ${TLS_SETTING} ${REGISTRY}/ovs-cni-plugin:${IMAGE_TAG}

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -9,7 +9,9 @@ RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 COPY . .
 
 ENV GOOS linux
-ENV GOARCH amd64
+# Support overriding target GOARCH during `make docker-build`
+ARG goarch=amd64
+ENV GOARCH=$goarch
 ENV CGO_ENABLED 0
 ENV GOFLAGS -mod=vendor
 

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -2,7 +2,8 @@
 
 destination=$1
 version=1.18.4
-tarball=go$version.linux-amd64.tar.gz
+arch="$(arch | sed s'/aarch64/arm64/' | sed s'/x86_64/amd64/')"
+tarball=go$version.linux-$arch.tar.gz
 url=https://dl.google.com/go/
 
 mkdir -p $destination


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the ability to optionally build binaries for arm64 by setting `GOARCH` via Makefile variable overrides.

For example:
```bash
make GOARCH=arm64 build

make GOARCH=arm64 docker-build
```
Also fixes the non-dockerized `install-go` script to correctly download/install the versioned golang under an arm64 host.

Combined, this permits building the plugin(s) for arm64 and/or x86 on either type of host.

**Special notes for your reviewer**:

Related to #260 

**Release note**:
```release-note
Ability to build arm64 binaries
```
