### PR TITLE
kubevirtci: Downgrade to 1.25

### DIFF
--- a/automation/check-patch.e2e.sh
+++ b/automation/check-patch.e2e.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.26-centos9'
+    export KUBEVIRT_PROVIDER='k8s-1.25'
 
     source automation/setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.26-centos9'}
-export KUBEVIRTCI_TAG=2305081329-48e913c
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
+export KUBEVIRTCI_TAG=2303201102-ef46217
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:
Align with CNAO.
Check if here the tests are passing.

**Special notes for your reviewer**:
Failures for example
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/k8snetworkplumbingwg_ovs-cni/279/pull-e2e-ovs-cni/1706970379018309632
pod can't be created `failed to find plugin "calico" in path [/opt/cni/bin]`
It seems we need to update calico according https://github.com/projectcalico/calico/pull/6218
but not sure this is the problem

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
