### PR TITLE
multus: Use thin version

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -30,5 +30,5 @@ for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); d
 done
 
 echo 'Deploying multus'
-./cluster/kubectl.sh apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.0.1/deployments/multus-daemonset-thick.yml
+./cluster/kubectl.sh apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.0.1/deployments/multus-daemonset.yml
 ./cluster/kubectl.sh -n kube-system rollout status daemonset kube-multus-ds --timeout 300s


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:
Calico officially supports only multus thin,
thick fails to create pods [1]
We don't need here thick so lets use thin meanwhile (as cnao does).

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/k8snetworkplumbingwg_ovs-cni/279/pull-e2e-ovs-cni/1706970379018309632

**Special notes for your reviewer**:
It seems we are using https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.0.1/deployments/multus-daemonset-thick.yml
which has `image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick`
same tag is used also on 4.0.2 and such, hence it might started to break suddenly when multus was changed.
Thin also have this problem (common tag between versions), so we should freeze by hash or so in a follow PR,
as CNAO does.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
