### PR TITLE
[release-0.29] fix: bump to fedora:38 in dockerized tests, because 34 is missing

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:34-x86_64
+FROM quay.io/fedora/fedora:38-x86_64
 
 RUN dnf -y install make git sudo gcc rsync-daemon rsync openvswitch hostname && \
     dnf -y clean all


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

Fedora 34 image is no longer available.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
