### PR TITLE
Add support for automatic bridge selection in HW offload mode

### DIFF
--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -50,7 +50,8 @@ Another example with a port which has an interface of type system:
 
 * `name` (string, required): the name of the network.
 * `type` (string, required): "ovs".
-* `bridge` (string, required): name of the bridge to use.
+* `bridge` (string, optional): name of the bridge to use, can be omitted if `ovnPort` is set in CNI_ARGS, or if `deviceID` is set
+* `deviceID` (string, optional): PCI address of a Virtual Function in valid sysfs format to use in HW offloading mode. This value is usually set by Multus.
 * `vlan` (integer, optional): VLAN ID of attached port. Trunk port if not
    specified.
 * `mtu` (integer, optional): MTU.
@@ -60,6 +61,11 @@ Another example with a port which has an interface of type system:
 * `interface_type` (string, optional): type of the interface belongs to ports. if value is "", ovs will use default interface of type 'internal'
 * `configuration_path` (optional): configuration file containing ovsdb
   socket file path, etc.
+
+
+_*Note:* if `deviceID` is provided, then it is possible to omit `bridge` argument. Bridge will be automatically selected by the CNI plugin by following
+the chain: Virtual Function PCI address (provided in `deviceID` argument) > Physical Function > Bond interface 
+(optional, if Physical Function is part of a bond interface) > ovs bridge_
 
 ### Flatfile Configuation
 

--- a/docs/ovs-offload.md
+++ b/docs/ovs-offload.md
@@ -125,6 +125,10 @@ spec:
     }'
 ```
 
+_*Note:* it is possible to omit `bridge` argument. Bridge will be automatically selected by the CNI plugin by following
+the chain: Virtual Function PCI address (injected by Multus to `deviceID` parameter) > Physical Function > Bond interface 
+(optional, if Physical Function is part of a bond interface) > ovs bridge_
+
 Now deploy a pod with the following config to attach VF into container and its representor net device
 attached with ovs bridge `br-snic0`.
 


### PR DESCRIPTION
Add support for automatic bridge selection in HW offload mode

If deviceID argument is passed it can be used for automatic bridge selection: VF deviceID > PF > Bond(Optional) > Bridge

**What this PR does / why we need it**:
This is required to optimize HW offloading use-case when Virtual Functions from multiple NICs on a host are exposed as a single resource.

Example:

We have two NICs on a host, and we want to expose all VFs from these NICs as a single resource.
To support HW offloading, each NIC should be attached to a separate OVS bridge.
Without changes from this PR, it is not possible to define NetworkAttachDefinition for OVS-cni, which will cover this use-case, because you need to explicitly specify the bridge name in the CNI config.

After changes from this PR, it is possible to define NetworkAttachDefinition without the bridge name and rely on the fact that ovs-cni will be able to automatically select the right OVS bridge (bridge to which NIC is attached) from the allocated Virtual Function (allocated by sriov device plugin, injected in `deviceID` field by multus)

**Special notes for your reviewer**:
Context is [Software bridge management](https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/640) feature in sriov-network-operator

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Added support for automatic bridge selection for HW offloading use-case.
if `deviceID` argument is set, then it is possible to omit `bridge` argument. Bridge will be automatically selected by the CNI plugin by following
the chain: Virtual Function PCI address (provided in `deviceID` argument) > Physical Function > Bond interface 
(optional, if Physical Function is part of a bond interface) > ovs bridge
```

cc @zeeke @adrianchiris @SchSeba 