### PR TITLE
fix: ovsdb.GetOvsPortForContIface should not return error if iface not found

### DIFF
--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -33,6 +33,10 @@ const (
 	ovsTable    = "Open_vSwitch"
 )
 
+var (
+	errObjectNotFound = errors.New("object not found")
+)
+
 // Bridge defines an object in Bridge table
 type Bridge struct {
 	UUID string `ovsdb:"_uuid"`
@@ -631,6 +635,9 @@ func (ovsd *OvsDriver) GetOvsPortForContIface(contIface, contNetnsPath string) (
 	colums := []string{"name", "external_ids"}
 	port, err := ovsd.findByCondition("Port", condition, colums)
 	if err != nil {
+		if errors.Is(err, errObjectNotFound) {
+			return "", false, nil
+		}
 		return "", false, err
 	}
 
@@ -745,7 +752,7 @@ func (ovsd *OvsDriver) findByCondition(table string, condition ovsdb.Condition, 
 	}
 
 	if len(operationResult.Rows) != 1 {
-		return nil, fmt.Errorf("failed to find object from table %s", table)
+		return nil, fmt.Errorf("%w in the table %s", errObjectNotFound, table)
 	}
 
 	return operationResult.Rows[0], nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the function returns `"",false, err` in case if interface not found.

The signature and usage of this function assume that the function should not return and error in case if interface not found.

Fix the function to return `"", false, nil` in case if the interface not found.

This change fixes CmdDel for scenario when CmdDel is called after failed CmdAdd or when port was manually removed from the ovs.
**Special notes for your reviewer**:

**Release note**:
```release-note
"NONE"
```

cc @SchSeba @e0ne