### PR TITLE
Add github actions to publish images to GH registry

### DIFF
--- a/.github/workflows/image-build-test.yaml
+++ b/.github/workflows/image-build-test.yaml
@@ -1,0 +1,35 @@
+name: image-build-test
+on: [push, pull_request]
+
+env:
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Prepare version file
+        run: ./hack/get_version.sh > .version
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          # no need to explicitly set goarch, 
+          # correct arch will be selected for each build platform 
+          build-args: |
+            goarch=
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          file: ./cmd/Dockerfile

--- a/.github/workflows/image-push-main.yaml
+++ b/.github/workflows/image-push-main.yaml
@@ -1,0 +1,57 @@
+name: "Push images on merge to main"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}-plugin
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+     
+      - name: Prepare version file
+        run: ./hack/get_version.sh > .version
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          # no need to explicitly set goarch, 
+          # correct arch will be selected for each build platform 
+          build-args: |
+            goarch=
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          file: ./cmd/Dockerfile
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/image-push-release.yaml
+++ b/.github/workflows/image-push-release.yaml
@@ -1,0 +1,58 @@
+name: "Push images on release"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}-plugin
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+      
+      - name: Prepare version file
+        run: ./hack/get_version.sh > .version
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          # no need to explicitly set goarch, 
+          # correct arch will be selected for each build platform 
+          build-args: |
+            goarch=
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          file: ./cmd/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY ?= quay.io/kubevirt
+REGISTRY ?= ghcr.io/k8snetworkplumbingwg
 IMAGE_TAG ?= latest
 IMAGE_GIT_TAG ?= $(shell git describe --abbrev=8 --tags)
 

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -36,7 +36,7 @@ REGISTRY=$registry make docker-push
 
 ovs_cni_manifest="./examples/ovs-cni.yml"
 
-sed 's/quay.io\/kubevirt/registry:5000/g' examples/ovs-cni.yml | ./cluster/kubectl.sh delete --ignore-not-found -f -
+sed 's/ghcr.io\/k8snetworkplumbingwg/registry:5000/g' examples/ovs-cni.yml | ./cluster/kubectl.sh delete --ignore-not-found -f -
 
 # Delete daemon sets that were deprecated/renamed
 ./cluster/kubectl.sh -n kube-system delete --ignore-not-found ds ovs-cni-plugin-amd64
@@ -50,4 +50,4 @@ until [ $(check_deleted "-f $ovs_cni_manifest") -eq 1 ]; do sleep 1; done
 until [ $(check_deleted "ds ovs-cni-plugin-amd64") -eq 1 ]; do sleep 1; done
 until [ $(check_deleted "ds ovs-vsctl-amd64") -eq 1 ]; do sleep 1; done
 
-sed 's/quay.io\/kubevirt/registry:5000/g' examples/ovs-cni.yml | ./cluster/kubectl.sh apply -f -
+sed 's/ghcr.io\/k8snetworkplumbingwg/registry:5000/g' examples/ovs-cni.yml | ./cluster/kubectl.sh apply -f -

--- a/examples/ovs-cni.yml
+++ b/examples/ovs-cni.yml
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       initContainers:
       - name: ovs-cni-plugin
-        image: quay.io/kubevirt/ovs-cni-plugin:latest
+        image: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:latest
         command: ["/bin/sh","-c"]
         args:
           - >
@@ -53,7 +53,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: ovs-cni-marker
-        image: quay.io/kubevirt/ovs-cni-plugin:latest
+        image: ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for multiach (linux/amd64,linux/arm64,linux/ppc64le) image build with GitHub actions and publish resulting images to Github registry.

**Special notes for your reviewer**:
Example of PR check:  https://github.com/ykulazhenkov/ovs-cni/actions/runs/8735994526
Example of push to master: https://github.com/ykulazhenkov/ovs-cni/actions/runs/8735447193
Example of push on release: https://github.com/ykulazhenkov/ovs-cni/actions/runs/8735569774

Example of artifacts: https://github.com/ykulazhenkov/ovs-cni/pkgs/container/ovs-cni

Validate binary arch:

```
root@cloud-dev-17:~/foo# docker pull --platform linux/arm64 ghcr.io/ykulazhenkov/ovs-cni:v0.0.1
v0.0.1: Pulling from ykulazhenkov/ovs-cni
0117dee8e815: Already exists 
0176767d615d: Already exists 
79424b46edd7: Already exists 
90e055d9c187: Already exists 
Digest: sha256:8b03ff2b9869dff82e07e26a80c3b9ce25c3e99c34abcc05ffae29c00c51d27c
Status: Downloaded newer image for ghcr.io/ykulazhenkov/ovs-cni:v0.0.1
ghcr.io/ykulazhenkov/ovs-cni:v0.0.1

root@cloud-dev-17:~/foo# docker create ghcr.io/ykulazhenkov/ovs-cni:v0.0.1
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v4) and no specific platform was requested
917e6995414181c0f56763b5848e58c11d46fe00932153126565b3add962d881

root@cloud-dev-17:~/foo# docker cp 917e6995414181c0f56763b5848e58c11d46fe00932153126565b3add962d881:/ovs .
Successfully copied 7.74MB to /root/foo/.

root@cloud-dev-17:~/foo# file ovs
ovs: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=ve0PYRQc45bRGHwoMZ6U/6uwx9CZDgopFlyJ4crUm/IPjfOx0tRjSzN9X3qlNH/Ih4mI5QNFRHHMAWezQzy, not stripped
```

**Release note**:
```release-note
NONE
```

Based on a great work by @zeeke in another k8snetworkplumbingwg repo.

@e0ne @SchSeba please, take a look
