### PR TITLE
Add PodUID to the OVSDB

### DIFF
--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -158,13 +158,13 @@ func (ovsd *OvsDriver) ovsdbTransact(ops []ovsdb.Operation) ([]ovsdb.OperationRe
 // **************** OVS driver API ********************
 
 // CreatePort Create an internal port in OVS
-func (ovsd *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string) error {
+func (ovsd *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contPodUid string) error {
 	intfUUID, intfOp, err := createInterfaceOperation(intfName, ofportRequest, ovnPortName, intfType)
 	if err != nil {
 		return err
 	}
 
-	portUUID, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTag, trunks, portType, intfUUID)
+	portUUID, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTag, trunks, portType, intfUUID, contPodUid)
 	if err != nil {
 		return err
 	}
@@ -658,7 +658,7 @@ func (ovsd *OvsDriver) GetOvsPortForContIface(contIface, contNetnsPath string) (
 		return "", false, err
 	}
 
-	condition := ovsdb.NewCondition("external_ids", ovsdb.ConditionEqual, ovsmap)
+	condition := ovsdb.NewCondition("external_ids", ovsdb.ConditionIncludes, ovsmap)
 	colums := []string{"name", "external_ids"}
 	port, err := ovsd.findByCondition("Port", condition, colums)
 	if err != nil {
@@ -853,7 +853,7 @@ func createInterfaceOperation(intfName string, ofportRequest uint, ovnPortName s
 	return intfUUID, &intfOp, nil
 }
 
-func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag uint, trunks []uint, portType string, intfUUID ovsdb.UUID) (ovsdb.UUID, *ovsdb.Operation, error) {
+func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag uint, trunks []uint, portType string, intfUUID ovsdb.UUID, contPodUid string) (ovsdb.UUID, *ovsdb.Operation, error) {
 	portUUIDStr := intfName
 	portUUID := ovsdb.UUID{GoUUID: portUUIDStr}
 
@@ -877,9 +877,10 @@ func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag 
 	}
 
 	oMap, err := ovsdb.NewOvsMap(map[string]string{
-		"contNetns": contNetnsPath,
-		"contIface": contIfaceName,
-		"owner":     ovsPortOwner,
+		"contPodUid": contPodUid,
+		"contNetns":  contNetnsPath,
+		"contIface":  contIfaceName,
+		"owner":      ovsPortOwner,
 	})
 	if err != nil {
 		return ovsdb.UUID{}, nil, err

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -50,8 +50,9 @@ import (
 // EnvArgs args containing common, desired mac and ovs port name
 type EnvArgs struct {
 	cnitypes.CommonArgs
-	MAC     cnitypes.UnmarshallableString `json:"mac,omitempty"`
-	OvnPort cnitypes.UnmarshallableString `json:"ovnPort,omitempty"`
+	MAC         cnitypes.UnmarshallableString `json:"mac,omitempty"`
+	OvnPort     cnitypes.UnmarshallableString `json:"ovnPort,omitempty"`
+	K8S_POD_UID cnitypes.UnmarshallableString
 }
 
 func init() {
@@ -168,8 +169,8 @@ func getBridgeName(driver *ovsdb.OvsDriver, bridgeName, ovnPort, deviceID string
 	return "", fmt.Errorf("failed to get bridge name")
 }
 
-func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contNetnsPath string, ovnPortName string) error {
-	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType, intfType)
+func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contNetnsPath string, ovnPortName string, contPodUid string) error {
+	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType, intfType, contPodUid)
 	if err != nil {
 		return err
 	}
@@ -247,9 +248,11 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	var mac string
 	var ovnPort string
+	var contPodUid string
 	if envArgs != nil {
 		mac = string(envArgs.MAC)
 		ovnPort = string(envArgs.OvnPort)
+		contPodUid = string(envArgs.K8S_POD_UID)
 	}
 
 	netconf, err := config.LoadConf(args.StdinData)
@@ -329,7 +332,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	if err = attachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, vlanTagNum, trunks, portType, netconf.InterfaceType, args.Netns, ovnPort); err != nil {
+	if err = attachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, vlanTagNum, trunks, portType, netconf.InterfaceType, args.Netns, ovnPort, contPodUid); err != nil {
 		return err
 	}
 	defer func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

By adding the UID of a Pod to the external_ids field of the corresponding veth interface in the OVSDB, it becomes convenient for the Pod object to query the OVSDB using the UID to find the vethName of the Pod on the host machine, and then deliver OVS flow tables accordingly.

Currently, the host machine's veth interface in the OVSDB only stores the Netns field, which is useful, but for Pod objects, their netns is not publicly accessible. This change addresses this limitation by allowing Pod objects to query the OVSDB directly using their UID.

**Special notes for your reviewer**:

**Release note**:


```release-note
Added the Pod UID to the external_ids field of the corresponding veth interface in the OVSDB.
This change allows querying the vethName of a Pod on the host machine using its UID, improving the ability to deliver OVS flow tables for Pod objects.
```