### PR TITLE
Bump go to 1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(BASE): ; $(info  setting GOPATH...)
 
 GOLANGCI = $(GOBIN)/golangci-lint
 $(GOBIN)/golangci-lint: | $(BASE) ; $(info  building golangci-lint...)
-	$Q go install -mod=mod github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	$Q go install -mod=mod github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
 
 build: format $(patsubst %, build-%, $(COMPONENTS))
 
@@ -83,7 +83,6 @@ docker-push:
 	$(OCI_BIN) push ${TLS_SETTING} ${REGISTRY}/ovs-cni-plugin:${IMAGE_GIT_TAG}
 
 dep: $(GO)
-	$(GO) mod tidy
 	$(GO) mod vendor
 
 manifests:

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -21,7 +21,7 @@ RUN go build -tags no_openssl -o /workdir/bin/marker ./cmd/marker
 RUN go build -tags no_openssl -o /workdir/bin/ovs-mirror-producer ./cmd/mirror-producer
 RUN go build -tags no_openssl -o /workdir/bin/ovs-mirror-consumer ./cmd/mirror-consumer
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-RUN microdnf install findutils
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+RUN microdnf install -y findutils
 COPY --from=builder /workdir/.version /.version
 COPY --from=builder /workdir/bin/* /

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8 as builder
+FROM quay.io/centos/centos:stream9 as builder
 
 RUN mkdir /workdir
 WORKDIR /workdir

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,4 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.1
 )
 
-go 1.18
+go 1.21

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:38-x86_64
+FROM quay.io/fedora/fedora:40-x86_64
 
 RUN dnf -y install make git sudo gcc rsync-daemon rsync openvswitch hostname && \
     dnf -y clean all
@@ -6,7 +6,7 @@ RUN dnf -y install make git sudo gcc rsync-daemon rsync openvswitch hostname && 
 ENV GOPATH="/go"
 RUN \
     DESTINATION=/opt && \
-    VERSION=1.18.4 && \
+    VERSION=1.21.7 && \
     TARBALL=go${VERSION}.linux-amd64.tar.gz && \
     URL=https://dl.google.com/go && \
     mkdir -p ${DESTINATION} && \

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 destination=$1
-version=1.18.4
+version=1.21.7
 arch="$(arch | sed s'/aarch64/arm64/' | sed s'/x86_64/amd64/')"
 tarball=go$version.linux-$arch.tar.gz
 url=https://dl.google.com/go/

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -165,7 +165,7 @@ func loadFlatNetConf[T types.NetConfs](configPath string) (*T, error) {
 				return nil, fmt.Errorf("open ovs config file %s error: %v", confFile, err)
 			}
 			defer jsonFile.Close()
-			jsonBytes, err := ioutil.ReadAll(jsonFile)
+			jsonBytes, err := io.ReadAll(jsonFile)
 			if err != nil {
 				return nil, fmt.Errorf("load ovs config file %s: error: %v", confFile, err)
 			}

--- a/pkg/sriov/cache.go
+++ b/pkg/sriov/cache.go
@@ -20,7 +20,6 @@ package sriov
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +58,7 @@ func saveScratchConf(containerID, dataDir string, conf []byte) error {
 
 	path := filepath.Join(dataDir, containerID)
 
-	err := ioutil.WriteFile(path, conf, 0600)
+	err := os.WriteFile(path, conf, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write container data in the path(%q): %v", path, err)
 	}
@@ -68,7 +67,7 @@ func saveScratchConf(containerID, dataDir string, conf []byte) error {
 }
 
 func readScratchConf(cRefPath string) ([]byte, error) {
-	data, err := ioutil.ReadFile(cRefPath)
+	data, err := os.ReadFile(cRefPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read container data in the path(%q): %v", cRefPath, err)
 	}

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -19,7 +19,6 @@ package sriov
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -44,7 +43,7 @@ func GetVFLinkName(pciAddr string) (string, error) {
 		return "", err
 	}
 
-	fInfos, err := ioutil.ReadDir(vfDir)
+	fInfos, err := os.ReadDir(vfDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read net dir of the device %s: %v", pciAddr, err)
 	}


### PR DESCRIPTION
Go 1.18 is old and no longer available in CentOS repositories.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
