### PR TITLE
cluster: Allow kubevirtci tag overriding

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.26-centos9'}
-export KUBEVIRTCI_TAG=2305081329-48e913c
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2305081329-48e913c}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -4,7 +4,15 @@ RUN mkdir /workdir
 WORKDIR /workdir
 
 COPY go.mod .
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
+
+RUN dnf install -y wget
+
+RUN GO_VERSION=$(sed -En 's/^go +(.*)$/\1/p' go.mod) && \
+    wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz
+
+ENV PATH /usr/local/go/bin:$PATH
 
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,4 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.1
 )
 
-go 1.21
+go 1.21.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:
It is helpful either manually or for example
when used from CNAO, to use same tag of the cluster that CNAO deployed.
Otherwise a kubevirtci tag mismatch can cause failures once running OVS e2e tests from CNAO.

Beside that fix go download, as the previous method doesn't work anymore.
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/k8snetworkplumbingwg_ovs-cni/319/pull-e2e-ovs-cni/1808463231954456576#1:build-log.txt%3A9859

go.mod was changed to fit the new download mechanism,
but anyhow lately this is common on all repos to add the patch, i.e kubevirt as well
that was changed lately https://github.com/kubevirt/kubevirt/blob/a3b2bf3a54936b3dedf1341f6927ba6bdda51557/go.mod#L210
This semantic is allowed, and even required when the toolchain arg will present.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
