### PR TITLE
Add support for userspace device drivers with HW offload mode

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -328,7 +328,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	var hostIface, contIface *current.Interface
 	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
-		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, netconf.MTU, netconf.DeviceID, userspaceMode)
+		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, mac, netconf.MTU, netconf.DeviceID, userspaceMode)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -291,6 +291,15 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// check if the device driver is the type of userspace driver
+	userspaceMode := false
+	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+		userspaceMode, err = sriov.HasUserspaceDriver(netconf.DeviceID)
+		if err != nil {
+			return err
+		}
+	}
+
 	// removes all ports whose interfaces have an error
 	if err := cleanPorts(ovsBridgeDriver); err != nil {
 		return err
@@ -302,8 +311,9 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 	defer contNetns.Close()
 
+	// userspace driver does not create a network interface for the VF on the host
 	var origIfName string
-	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) && !userspaceMode {
 		origIfName, err = sriov.GetVFLinkName(netconf.DeviceID)
 		if err != nil {
 			return err
@@ -312,13 +322,13 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	// Cache NetConf for CmdDel
 	if err = utils.SaveCache(config.GetCRef(args.ContainerID, args.IfName),
-		&types.CachedNetConf{Netconf: netconf, OrigIfName: origIfName}); err != nil {
+		&types.CachedNetConf{Netconf: netconf, OrigIfName: origIfName, UserspaceMode: userspaceMode}); err != nil {
 		return fmt.Errorf("error saving NetConf %q", err)
 	}
 
 	var hostIface, contIface *current.Interface
 	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
-		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, netconf.MTU, netconf.DeviceID)
+		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, netconf.MTU, netconf.DeviceID, userspaceMode)
 		if err != nil {
 			return err
 		}
@@ -353,7 +363,9 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// run the IPAM plugin
-	if netconf.IPAM.Type != "" {
+	// userspace driver does not support IPAM plugin,
+	// because there is no network interface for the VF on the host
+	if netconf.IPAM.Type != "" && !userspaceMode {
 		var r cnitypes.Result
 		r, err = ipam.ExecAdd(netconf.IPAM.Type, args.StdinData)
 		defer func() {
@@ -562,8 +574,11 @@ func CmdDel(args *skel.CmdArgs) error {
 				// port is already deleted in a previous invocation.
 				log.Printf("Error: %v\n", err)
 			}
-			if err = sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
-				return err
+			// there is no network interface in case of userspace driver, so OrigIfName is empty
+			if !cache.UserspaceMode {
+				if err = sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
+					return err
+				}
 			}
 		} else {
 			// In accordance with the spec we clean up as many resources as possible.
@@ -591,11 +606,14 @@ func CmdDel(args *skel.CmdArgs) error {
 	}
 
 	if sriov.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
-		err = sriov.ReleaseVF(args, cache.OrigIfName)
-		if err != nil {
-			// try to reset vf into original state as much as possible in case of error
-			if err := sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
-				log.Printf("Failed best-effort cleanup of VF %s: %v", cache.OrigIfName, err)
+		// there is no network interface in case of userspace driver, so OrigIfName is empty
+		if !cache.UserspaceMode {
+			err = sriov.ReleaseVF(args, cache.OrigIfName)
+			if err != nil {
+				// try to reset vf into original state as much as possible in case of error
+				if err := sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
+					log.Printf("Failed best-effort cleanup of VF %s: %v", cache.OrigIfName, err)
+				}
 			}
 		}
 	} else {
@@ -633,14 +651,6 @@ func CmdCheck(args *skel.CmdArgs) error {
 	}
 	ovsHWOffloadEnable := sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID)
 
-	// run the IPAM plugin
-	if netconf.NetConf.IPAM.Type != "" {
-		err = ipam.ExecCheck(netconf.NetConf.IPAM.Type, args.StdinData)
-		if err != nil {
-			return fmt.Errorf("failed to check with IPAM plugin type %q: %v", netconf.NetConf.IPAM.Type, err)
-		}
-	}
-
 	envArgs, err := getEnvArgs(args.Args)
 	if err != nil {
 		return err
@@ -670,6 +680,21 @@ func CmdCheck(args *skel.CmdArgs) error {
 
 	if err := validateCache(cache, netconf); err != nil {
 		return err
+	}
+
+	// TODO: CmdCheck for userspace driver
+	if cache.UserspaceMode {
+		return nil
+	}
+
+	// run the IPAM plugin
+	// userspace driver does not support IPAM plugin,
+	// because there is no network interface for the VF on the host
+	if netconf.NetConf.IPAM.Type != "" && !cache.UserspaceMode {
+		err = ipam.ExecCheck(netconf.NetConf.IPAM.Type, args.StdinData)
+		if err != nil {
+			return fmt.Errorf("failed to check with IPAM plugin type %q: %v", netconf.NetConf.IPAM.Type, err)
+		}
 	}
 
 	// Parse previous result.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -71,13 +71,15 @@ type Trunk struct {
 	ID    *uint `json:"id,omitempty"`
 }
 
-// CachedNetConf containing NetConfig and original smartnic vf interface
-// name (set only in case of ovs hareware offload scenario).
+// CachedNetConf containing NetConfig, original smartnic vf interface name
+// and kernel/userspace device driver mode of the smartnic vf interface
+// (the last two are set only in case of ovs hareware offload scenario).
 // this is intended to be used only for storing and retrieving config
 // to/from a data store (example file cache).
 type CachedNetConf struct {
-	Netconf    *NetConf
-	OrigIfName string
+	Netconf       *NetConf
+	OrigIfName    string
+	UserspaceMode bool
 }
 
 // CachedPrevResultNetConf containing PrevResult.


### PR DESCRIPTION
Add support for SR-IOV Virtual Functions (VFs) using both hardware offload (switchdev) and userspace device drivers such as vfio-pci.
If the MAC address is provided via arguments, update the VF’s MAC address accordingly using netlink.

**What this PR does / why we need it**:

This feature is essential for scenarios where SR-IOV VFs require both userspace device drivers and hardware offload.
For instance, containerized network functions with Intel E810 may enable eswitch switchdev mode for hardware offload while using the vfio-pci driver for running DPDK or VPP.
Another use case is the [KubeVirt SR-IOV Interface](https://kubevirt.io/user-guide/network/interfaces_and_networks/#sriov).
After merging this PR, users can create a KubeVirt VM supported by OVS hardware offload without modifying the KubeVirt source code.

**Special notes for your reviewer**:

Even in scenarios where userspace device drivers are employed, and there is no netdevice for the VF on the host, the CNI should still return the name and sandbox for the VF interface to be recognized by Multus.

**Release note**:

```release-note
- Support HW offload with userspace device driver
- Support MAC address update in HW offload mode
```
