### PR TITLE
pull e2e ovs-cni fix: install latest ginkgo

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     tar -xzf cni-plugins-linux-amd64-v1.0.1.tgz && \
     rm -f cni-plugins-linux-amd64-v1.0.1.tgz
 
-RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
getting this error in the ci job when trying to pull e2e ovs-cni: go: 'go install' requires a version when current directory is not in a module

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
