### PR TITLE
Add support for s390x architecture in GitHub Actions workflows.

### DIFF
--- a/.github/workflows/image-build-test.yaml
+++ b/.github/workflows/image-build-test.yaml
@@ -2,7 +2,7 @@ name: image-build-test
 on: [push, pull_request]
 
 env:
-  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 jobs:
   build-image:

--- a/.github/workflows/image-push-main.yaml
+++ b/.github/workflows/image-push-main.yaml
@@ -2,7 +2,7 @@ name: "Push images on merge to main"
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}-plugin
-  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 on:
   push:

--- a/.github/workflows/image-push-release.yaml
+++ b/.github/workflows/image-push-release.yaml
@@ -2,7 +2,7 @@ name: "Push images on release"
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}-plugin
-  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 on:
   push:

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -2,7 +2,8 @@
 
 destination=$1
 version=$(curl -s https://go.dev/dl/?mode=json | jq -r ".[0].version")
-tarball=$version.linux-amd64.tar.gz
+arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+tarball=$version.linux-$arch.tar.gz
 url=https://dl.google.com/go/
 
 mkdir -p $destination


### PR DESCRIPTION
Updated GitHub Actions workflows to include linux/s390x in BUILD_PLATFORMS. Modified hack/install-go.sh to dynamically select the appropriate Go tarball based on the system's architecture(amd64, arm64, or others), allowing better support for multi-architecture environments.

**What this PR does / why we need it**:
these changes enhances GitHub Actions workflows by adding linux/s390x to BUILD_PLATFORMS. 
also updates hack/install-go.sh to automatically select the correct Go tarball based on the system architecture (amd64, arm64, or others), improving support for multi-architecture environments.

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
