### PR TITLE
Add port pod namespace name to port creation

### DIFF
--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -158,13 +158,13 @@ func (ovsd *OvsDriver) ovsdbTransact(ops []ovsdb.Operation) ([]ovsdb.OperationRe
 // **************** OVS driver API ********************
 
 // CreatePort Create an internal port in OVS
-func (ovsd *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string) error {
+func (ovsd *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, podNamespaceName, ovnPortName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string) error {
 	intfUUID, intfOp, err := createInterfaceOperation(intfName, ofportRequest, ovnPortName, intfType)
 	if err != nil {
 		return err
 	}
 
-	portUUID, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTag, trunks, portType, intfUUID)
+	portUUID, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, podNamespaceName, vlanTag, trunks, portType, intfUUID)
 	if err != nil {
 		return err
 	}
@@ -853,7 +853,7 @@ func createInterfaceOperation(intfName string, ofportRequest uint, ovnPortName s
 	return intfUUID, &intfOp, nil
 }
 
-func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag uint, trunks []uint, portType string, intfUUID ovsdb.UUID) (ovsdb.UUID, *ovsdb.Operation, error) {
+func createPortOperation(intfName, contNetnsPath, contIfaceName, podNamespaceName string, vlanTag uint, trunks []uint, portType string, intfUUID ovsdb.UUID) (ovsdb.UUID, *ovsdb.Operation, error) {
 	portUUIDStr := intfName
 	portUUID := ovsdb.UUID{GoUUID: portUUIDStr}
 
@@ -880,6 +880,7 @@ func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag 
 		"contNetns": contNetnsPath,
 		"contIface": contIfaceName,
 		"owner":     ovsPortOwner,
+		"pod":       podNamespaceName,
 	})
 	if err != nil {
 		return ovsdb.UUID{}, nil, err

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
 	"math/rand"
 	"net"
 	"os/exec"
@@ -36,6 +35,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
 	"github.com/vishvananda/netlink"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -678,10 +678,10 @@ var testFunc = func(version string) {
 				}()
 
 				By("Checking that both namespaces have different mac addresses on eth0")
-				resultOne := attach(targetNsOne, conf, IFNAME, "", "")
+				resultOne := attach(targetNsOne, conf, IFNAME, "", "", "", "")
 				contOneIface := resultOne.Interfaces[0]
 
-				resultTwo := attach(targetNsTwo, conf, IFNAME, "", "")
+				resultTwo := attach(targetNsTwo, conf, IFNAME, "", "", "", "")
 				contTwoIface := resultTwo.Interfaces[1]
 
 				Expect(contOneIface.Mac).NotTo(Equal(contTwoIface.Mac))
@@ -705,7 +705,7 @@ var testFunc = func(version string) {
 
 				By("Checking that the mac address on eth0 equals to the requested one")
 				mac := "0a:00:00:00:00:80"
-				result := attach(targetNs, conf, IFNAME, mac, "")
+				result := attach(targetNs, conf, IFNAME, mac, "", "", "")
 				contIface := result.Interfaces[1]
 
 				Expect(contIface.Mac).To(Equal(mac))
@@ -728,7 +728,30 @@ var testFunc = func(version string) {
 				}()
 
 				OvnPort := "test-port"
-				result := attach(targetNs, conf, IFNAME, "", OvnPort)
+				result := attach(targetNs, conf, IFNAME, "", OvnPort, "", "")
+				hostIface := result.Interfaces[0]
+				output, err := exec.Command("ovs-vsctl", "--column=external_ids", "find", "Interface", fmt.Sprintf("name=%s", hostIface.Name)).CombinedOutput()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(output[:len(output)-1])).To(Equal(ovsOutput))
+			})
+		})
+		Context("specific pod name and namespace", func() {
+			It("should configure pod namespace name", func() {
+				const ovsOutput = "external_ids        : {pod=default/some-pod}"
+
+				conf := fmt.Sprintf(`{
+				"cniVersion": "%s",
+				"name": "mynet",
+				"type": "ovs",
+				"OvnPort": "test-port",
+				"bridge": "%s"}`, version, bridgeName)
+
+				targetNs := newNS()
+				defer func() {
+					closeNS(targetNs)
+				}()
+
+				result := attach(targetNs, conf, IFNAME, "", "", "some-pod", "default")
 				hostIface := result.Interfaces[0]
 				output, err := exec.Command("ovs-vsctl", "--column=external_ids", "find", "Interface", fmt.Sprintf("name=%s", hostIface.Name)).CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
@@ -753,7 +776,7 @@ var testFunc = func(version string) {
 					closeNS(targetNs)
 				}()
 
-				result := attach(targetNs, conf, IFNAME, "", "")
+				result := attach(targetNs, conf, IFNAME, "", "", "", "")
 				hostIface := result.Interfaces[0]
 
 				// Wait for OVS to actually assign the port, even when the add returns
@@ -858,8 +881,8 @@ var testFunc = func(version string) {
 				}()
 
 				// Create two ports for two separate target namespaces.
-				firstResult := attach(firstTargetNs, conf, IFNAME, "", "test-port-1")
-				secondResult := attach(secondTargetNs, conf, IFNAME, "", "test-port-2")
+				firstResult := attach(firstTargetNs, conf, IFNAME, "", "test-port-1", "", "")
+				secondResult := attach(secondTargetNs, conf, IFNAME, "", "test-port-2", "", "")
 
 				// Remove the host interface of the first port. This makes the
 				// port faulty. Our test should remove the interfaces of this
@@ -907,7 +930,7 @@ var testFunc = func(version string) {
 	})
 }
 
-func attach(namespace ns.NetNS, conf, ifName, mac, ovnPort string) *current.Result {
+func attach(namespace ns.NetNS, conf, ifName, mac, ovnPort, podName, podNamespace string) *current.Result {
 	extraArgs := ""
 	if mac != "" {
 		extraArgs += fmt.Sprintf("MAC=%s,", mac)
@@ -915,6 +938,10 @@ func attach(namespace ns.NetNS, conf, ifName, mac, ovnPort string) *current.Resu
 
 	if ovnPort != "" {
 		extraArgs += fmt.Sprintf("OvnPort=%s", ovnPort)
+	}
+
+	if podName != "" && podNamespace != "" {
+		extraArgs += fmt.Sprintf("K8S_POD_NAME=%s;K8S_POD_NAMESPACE=%s", podName, podNamespace)
 	}
 
 	extraArgs = strings.TrimSuffix(extraArgs, ",")


### PR DESCRIPTION
Adding external_id to port creation with pod namespace/name it will enable easy serch between ovs port and port inside the container

**What this PR does / why we need it**:

In case another SDN controller need want to use ovs ports in oder to add specific flows related to the network configuration inside the pod it will be easer to find the relevant port in OVS


