### PR TITLE
feat: simplify renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,6 @@
     "release-0.34"
   ],
   "prConcurrentLimit": 3,
-  "groupName": "all dependencies",
-  "groupSlug": "all",
   "lockFileMaintenance": {
     "enabled": false
   },
@@ -25,34 +23,14 @@
     "hack/**",
     "manifests/**"
   ],
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
-      "groupName": "all dependencies on main",
-      "matchBaseBranches": [
-        "main"
-      ],
-      "matchPackagePatterns": [
-        "*"
-      ]
-    },
-    {
-      "groupName": "only security dependencies on stable",
+      "groupName": "all dependencies",
+      "groupSlug": "all",
       "enabled": false,
-      "matchBaseBranches": [
-        "release-0.34"
-      ],
       "matchPackagePatterns": [
         "*"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "golang",
-        "go"
-      ],
-      "allowedVersions": "<=1.22",
-      "matchBaseBranches": [
-        "release-0.34"
       ]
     }
   ],
@@ -61,5 +39,5 @@
   },
   "osvVulnerabilityAlerts": true,
   "assigneesFromCodeOwners": true,
-  "separateMajorMinor": false
+  "separateMajorMinor": true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: simplify renovate config

Disable regular updates, because they did not work as expected, only security updates are kept. Removed configuration for go version, since it did not work as we need. Removed grouping of the dependency PRs, since it complicated the bumping of the dependencies

**Release note**:
```
NONE
```
