### PR TITLE
Pin to an older version of Ginkgo and change builder image

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,10 +1,7 @@
-FROM quay.io/centos/centos:stream8 as builder
+FROM quay.io/projectquay/golang:1.18 as builder
 
 RUN mkdir /workdir
 WORKDIR /workdir
-
-COPY go.mod .
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     tar -xzf cni-plugins-linux-amd64-v1.0.1.tgz && \
     rm -f cni-plugins-linux-amd64-v1.0.1.tgz
 
-RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.14.0
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

This is the last version compatible with 1.18. Not pinning pulls a version requiring 1.22. This will be later backported down to 0.29.

Stream 8 seems to be offline and we fail to pull RPMs from the repositories. This PR replaces Stream 8  by a dedicated Go 1.18 build image.

**Special notes for your reviewer**:

These two must be bundled together, otherwise one fails without the other.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
