### PR TITLE
[release-0.31] Pin to an older version of Ginkgo and change builder and kubevirtci images

### DIFF
--- a/automation/check-patch.e2e.sh
+++ b/automation/check-patch.e2e.sh
@@ -12,7 +12,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.23'
+    export KUBEVIRT_PROVIDER='k8s-1.26-centos9'
 
     source automation/setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG=2211021552-8cca8c0
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.26-centos9'}
+export KUBEVIRTCI_TAG=2305081329-48e913c
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -34,4 +34,4 @@ curl https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v3.9.1/de
 MULTUS_IMAGE=ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9
 sed -i "s#ghcr.io/k8snetworkplumbingwg/multus-cni:stable\$#$MULTUS_IMAGE#" cluster/multus-daemonset.yml
 ./cluster/kubectl.sh create -f cluster/multus-daemonset.yml
-./cluster/kubectl.sh -n kube-system wait --for=condition=ready -l name=multus pod --timeout=300s
+./cluster/kubectl.sh rollout status daemonset -l name=multus -n kube-system --timeout=300s

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -23,10 +23,10 @@ $(cluster::path)/cluster-up/up.sh
 
 echo 'Installing Open vSwitch on nodes'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-    ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
-    ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 dpdk
     ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
+    ./cluster/cli.sh ssh ${node} -- sudo systemctl enable openvswitch
     ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
+    ./cluster/cli.sh ssh ${node} -- sudo systemctl restart NetworkManager
 done
 
 echo 'Deploying multus'

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,10 +1,7 @@
-FROM quay.io/centos/centos:stream8 as builder
+FROM quay.io/projectquay/golang:1.18 as builder
 
 RUN mkdir /workdir
 WORKDIR /workdir
-
-COPY go.mod .
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     tar -xzf cni-plugins-linux-amd64-v1.0.1.tgz && \
     rm -f cni-plugins-linux-amd64-v1.0.1.tgz
 
-RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.14.0
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

Old versions of the builder image was taken offline. The openvswitch repo used in kubevirtci script was taken offline. The unpinned (latest) Ginkgo is not compatible with Go 1.18.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
