### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/examples/ovs-cni.yml
+++ b/examples/ovs-cni.yml
@@ -89,6 +89,7 @@ spec:
                 find /tmp/healthy -mmin -2 | grep -q '/tmp/healthy'
           initialDelaySeconds: 60
           periodSeconds: 60
+        terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cnibin
           hostPath:

--- a/manifests/ovs-cni.yml.in
+++ b/manifests/ovs-cni.yml.in
@@ -89,6 +89,7 @@ spec:
                 find /tmp/healthy -mmin -2 | grep -q '/tmp/healthy'
           initialDelaySeconds: ${OVS_CNI_MARKER_HEALTHCHECK_INTERVAL}
           periodSeconds: ${OVS_CNI_MARKER_HEALTHCHECK_INTERVAL}
+        terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cnibin
           hostPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
To comply with best practices, all the containers in all the pods, must set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
