### PR TITLE
manifests: Add readiness probe

### DIFF
--- a/manifests/ovs-cni.yml.in
+++ b/manifests/ovs-cni.yml.in
@@ -89,6 +89,15 @@ spec:
                 find /tmp/healthy -mmin -2 | grep -q '/tmp/healthy'
           initialDelaySeconds: ${OVS_CNI_MARKER_HEALTHCHECK_INTERVAL}
           periodSeconds: ${OVS_CNI_MARKER_HEALTHCHECK_INTERVAL}
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - >-
+                find /tmp/healthy -mmin -2 | grep -q '/tmp/healthy'
+          initialDelaySeconds: ${OVS_CNI_MARKER_HEALTHCHECK_INTERVAL}
+          periodSeconds: ${OVS_CNI_MARKER_HEALTHCHECK_INTERVAL}
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: cnibin


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a readiness probe to the DaemonSet

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add readiness probe
```
