### PR TITLE
Support reading OvnPort from args.cni

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -277,6 +277,17 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// Check for OvnPort and MAC in args.cni (CNI convention)
+	// args.cni takes precedence over CNI_ARGS per CNI spec
+	if netconf.Args != nil && netconf.Args.CNI != nil {
+		if netconf.Args.CNI.OvnPort != "" {
+			ovnPort = netconf.Args.CNI.OvnPort
+		}
+		if netconf.Args.CNI.MAC != "" {
+			mac = netconf.Args.CNI.MAC
+		}
+	}
+
 	var vlanTagNum uint = 0
 	trunks := make([]uint, 0)
 	portType := "access"
@@ -558,6 +569,12 @@ func CmdDel(args *skel.CmdArgs) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	// Check for OvnPort in args.cni (CNI convention) - takes precedence
+	if cache.Netconf.Args != nil && cache.Netconf.Args.CNI != nil {
+		if cache.Netconf.Args.CNI.OvnPort != "" {
+			ovnPort = cache.Netconf.Args.CNI.OvnPort
+		}
+	}
 	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
 	if err != nil {
 		return err
@@ -678,6 +695,12 @@ func CmdCheck(args *skel.CmdArgs) error {
 	var ovnPort string
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
+	}
+	// Check for OvnPort in args.cni (CNI convention) - takes precedence
+	if netconf.Args != nil && netconf.Args.CNI != nil {
+		if netconf.Args.CNI.OvnPort != "" {
+			ovnPort = netconf.Args.CNI.OvnPort
+		}
 	}
 	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -26,6 +26,13 @@ type NetConfs interface {
 	NetConf | MirrorNetConf
 }
 
+// CNIArgs contains arguments passed via args.cni in the CNI config
+// This follows CNI conventions: https://www.cni.dev/docs/conventions/
+type CNIArgs struct {
+	OvnPort string `json:"OvnPort,omitempty"`
+	MAC     string `json:"MAC,omitempty"`
+}
+
 // NetConf extends types.NetConf for ovs-cni
 type NetConf struct {
 	types.NetConf
@@ -40,6 +47,10 @@ type NetConf struct {
 	SocketFile             string   `json:"socket_file"`
 	LinkStateCheckRetries  int      `json:"link_state_check_retries"`
 	LinkStateCheckInterval int      `json:"link_state_check_interval"`
+	// Args contains CNI args passed via args.cni in the config
+	Args *struct {
+		CNI *CNIArgs `json:"cni,omitempty"`
+	} `json:"args,omitempty"`
 }
 
 // MirrorNetConf extends types.NetConf for ovs-mirrors

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 VEXXHOST, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNetConfArgsCNIParsing(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         string
+		expectedOvnPort string
+		expectedMAC    string
+	}{
+		{
+			name: "args.cni with OvnPort",
+			config: `{
+				"cniVersion": "1.0.0",
+				"name": "test-net",
+				"type": "ovs",
+				"bridge": "br-int",
+				"args": {
+					"cni": {
+						"OvnPort": "test-port-id"
+					}
+				}
+			}`,
+			expectedOvnPort: "test-port-id",
+			expectedMAC:    "",
+		},
+		{
+			name: "args.cni with OvnPort and MAC",
+			config: `{
+				"cniVersion": "1.0.0",
+				"name": "test-net",
+				"type": "ovs",
+				"bridge": "br-int",
+				"args": {
+					"cni": {
+						"OvnPort": "my-ovn-port",
+						"MAC": "fa:16:3e:aa:bb:cc"
+					}
+				}
+			}`,
+			expectedOvnPort: "my-ovn-port",
+			expectedMAC:    "fa:16:3e:aa:bb:cc",
+		},
+		{
+			name: "no args section",
+			config: `{
+				"cniVersion": "1.0.0",
+				"name": "test-net",
+				"type": "ovs",
+				"bridge": "br-int"
+			}`,
+			expectedOvnPort: "",
+			expectedMAC:    "",
+		},
+		{
+			name: "empty args.cni",
+			config: `{
+				"cniVersion": "1.0.0",
+				"name": "test-net",
+				"type": "ovs",
+				"bridge": "br-int",
+				"args": {
+					"cni": {}
+				}
+			}`,
+			expectedOvnPort: "",
+			expectedMAC:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var netconf NetConf
+			if err := json.Unmarshal([]byte(tt.config), &netconf); err != nil {
+				t.Fatalf("Failed to unmarshal config: %v", err)
+			}
+
+			var gotOvnPort, gotMAC string
+			if netconf.Args != nil && netconf.Args.CNI != nil {
+				gotOvnPort = netconf.Args.CNI.OvnPort
+				gotMAC = netconf.Args.CNI.MAC
+			}
+
+			if gotOvnPort != tt.expectedOvnPort {
+				t.Errorf("OvnPort = %q, want %q", gotOvnPort, tt.expectedOvnPort)
+			}
+			if gotMAC != tt.expectedMAC {
+				t.Errorf("MAC = %q, want %q", gotMAC, tt.expectedMAC)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for reading `OvnPort` and `MAC` from `args.cni` in the CNI configuration, following [CNI conventions](https://www.cni.dev/docs/conventions/).

Multus passes `cni-args` from pod annotations via the `args.cni` field in the JSON config, not through `CNI_ARGS` environment variable. This enables ovs-cni to work with Multus annotations like:

```yaml
k8s.v1.cni.cncf.io/networks: '[{ "name": "ovn-net", "cni-args": {"OvnPort": "port-id"} }]'
```

Per the CNI spec, `args.cni` takes precedence over the deprecated `CNI_ARGS` when both are present. Full backward compatibility is maintained.

**Special notes for your reviewer**:

This follows the same pattern used by other CNI plugins like `host-local` IPAM for reading `args.cni`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Support reading OvnPort and MAC from args.cni, enabling Multus cni-args annotations to configure OVN port bindings.
```
