### PR TITLE
Support vhost_vdpa devices

### DIFF
--- a/docs/vdpa.md
+++ b/docs/vdpa.md
@@ -1,0 +1,134 @@
+# VDPA
+
+This document covers ovs-cni support of vdpa devices. It describes how
+they are supported, how to configure the environment and how to attach
+vdpa devices to a ovs bridge by using ovs-cni.
+
+## Support
+
+VDPA devices can be backed up by a SR-IOV virtual function or a VDUSE
+management device.
+
+VDPA devices can be bound to a virtio or a vhost driver.
+
+Currently, ovs-cni supports VDPA devices backed up by SR-IOV virtual
+functions and bound to the vhost_vdpa driver.
+
+## Environment preparation
+
+There are several steps to take before attaching a vdpa device to a pod
+through ovs-cni
+
+### Prerequisites
+
+- Mellanox ConnectX-6 dx NIC
+- [sriov-network-device-plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin)
+- [multus-cni](https://github.com/k8snetworkplumbingwg/multus-cni)
+- [network-resources-injector](https://github.com/k8snetworkplumbingwg/network-resources-injector)
+
+### VDPA device creation
+
+VDPA devices can be created by using the
+[sriov-network-operator][sriov-net-op]. However, this document covers
+creating vdpa devices without relying on the operator.
+
+#### ConnectX-6 Dx
+
+Create some VFs by:
+
+```bash
+echo 2 > /sys/class/net/ens1f0np0/device/sriov_numvfs
+```
+
+Unbind the mlx5 driver, change the e-switch mode into switchdev, and
+bind the drivers back:
+
+```bash
+echo 0000:65:00.0 > sys/bus/pci/drivers/mlx5_core/unbind
+echo 0000:65:00.1 > sys/bus/pci/drivers/mlx5_core/unbind
+devlink dev eswitch set pci/0000:65:00.0 mode switchdev
+devlink dev eswitch set pci/0000:65:00.1 mode switchdev
+echo 0000:65:00.0 > sys/bus/pci/drivers/mlx5_core/bind
+echo 0000:65:00.1 > sys/bus/pci/drivers/mlx5_core/bind
+```
+
+Load drivers
+
+```bash
+modprobe vdpa
+modprobe vhost_vdpa
+modprobe mlx5_vdpa
+```
+
+Check the available mgmtdevs:
+
+```bash
+vdpa mgmtdev show
+```
+
+Create the vdpa devices:
+```bash
+vdpa dev add name vdpa:0000:65:00.0 mgmtdev pci/0000:65:00.0 mac 02:11:22:33:44:55
+vdpa dev add name vdpa:0000:65:00.1 mgmtdev pci/0000:65:00.1 mac 02:11:22:33:44:66
+```
+
+### Device plugin configuration
+
+Just for demo purposes this document proposes a device plugin configuration
+that selects devices based on the PF name. Write/edit
+`/etc/pcidp/config.json` so it looks like:
+
+```json
+{
+    "resourceList": [{
+            "resourceName": "mlx-vdpa",
+            "selectors": {
+                "pfNames": ["ens1f0np0"]
+            }
+        }
+    ]
+}
+```
+
+Now the device plugin should advertise the vdpa devices created in the
+previous section.
+
+## NAD configuration
+
+ovs-cni relies on the device-info file to know whether the underlying
+device being configured for the network is a vdpa device. To make the
+CNI device-info aware, the path to the DeviceInfo file must be passed by
+multus. To do so, the `CNIDeviceInfoFile` capability must be enabled in
+the ovs network.
+
+Assuming that an OVS bridge called `br-vdpa` already exists, a network
+attachment definition must be created now, glueing everything together:
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/mlx-vdpa
+  name: ovs-vdpa-net
+spec:
+  config: |-
+    {
+        "cniVersion": "4.0.0",
+        "name": "ovs-vdpa-net",
+        "type": "ovs",
+        "capabilities": {
+            "CNIDeviceInfoFile": true
+        },
+        "bridge": "br-vdpa",
+        "ipam": {}
+    }
+```
+
+Remember that ipam is not supported for `vhost_vdpa`, as there is not
+interface in the host or pod that can be assigned an IP directly. It
+must be the guest doing that, which the CNI does not have access to.
+
+Pods attached to `ovs-vdpa-net` will be configured a `vhost_vdpa` device
+that is attached to the `br-vdpa` OVS bridge. The ovs-cni will configure
+the network device and bridge port attachment. The network resources
+injector will handle the resource request injection into the pod spec.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containernetworking/plugins v1.8.0
 	github.com/golang/glog v1.2.5
 	github.com/j-keck/arping v1.0.3
+	github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/k8snetworkplumbingwg/sriovnet v1.2.0
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containernetworking/plugins v1.9.1
 	github.com/golang/glog v1.2.5
 	github.com/j-keck/arping v1.0.3
+	github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/k8snetworkplumbingwg/sriovnet v1.2.0
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f h1:LQtn/QM21xLLxENWYdCuuyBZs0jO8J0vt9aB9G2H5nU=
+github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f/go.mod h1:w+XfqnQFjNnng94Uy1j4OFtkeCEH204rOH0Hn6zncLg=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/k8snetworkplumbingwg/sriovnet v1.2.0 h1:6ELfAxCB1dvosGUy3DVRmfH+HWTzmPD3W67HKQvMR1M=

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f h1:LQtn/QM21xLLxENWYdCuuyBZs0jO8J0vt9aB9G2H5nU=
+github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f/go.mod h1:w+XfqnQFjNnng94Uy1j4OFtkeCEH204rOH0Hn6zncLg=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/k8snetworkplumbingwg/sriovnet v1.2.0 h1:6ELfAxCB1dvosGUy3DVRmfH+HWTzmPD3W67HKQvMR1M=

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -17,8 +17,10 @@ package common
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
 
@@ -112,4 +114,21 @@ func GetBridgeName(bridgeName, ovnPort string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to get bridge name")
+}
+
+// CleanPorts removes all ports whose interfaces have an error.
+func CleanPorts(ovsDriver *ovsdb.OvsBridgeDriver) error {
+	ifaces, err := ovsDriver.FindInterfacesWithError()
+	if err != nil {
+		return fmt.Errorf("clean ports: %v", err)
+	}
+	for _, iface := range ifaces {
+		log.Printf("Info: interface %s has error: removing corresponding port", iface)
+		if err := ovsDriver.DeletePort(iface); err != nil {
+			// Don't return an error here, just log its occurrence.
+			// Something else may have removed the port already.
+			log.Printf("Error: %v\n", err)
+		}
+	}
+	return nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 
@@ -496,4 +497,19 @@ func CacheLoadAndCheck(args *skel.CmdArgs, netconf *types.NetConf) (*types.Cache
 	}
 
 	return cache, nil
+}
+
+// ParsePrevResult parses the previous CNI result from netconf
+func ParsePrevResult(netconf *types.NetConf) (*current.Result, error) {
+	if netconf.NetConf.RawPrevResult == nil {
+		return nil, fmt.Errorf("Required prevResult missing")
+	}
+	if err := version.ParsePrevResult(&netconf.NetConf); err != nil {
+		return nil, err
+	}
+	result, err := current.NewResultFromResult(netconf.NetConf.PrevResult)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -20,6 +20,10 @@ import (
 	"log"
 	"sort"
 
+	"github.com/vishvananda/netlink"
+
+	current "github.com/containernetworking/cni/pkg/types/100"
+
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
@@ -130,5 +134,14 @@ func CleanPorts(ovsDriver *ovsdb.OvsBridgeDriver) error {
 			log.Printf("Error: %v\n", err)
 		}
 	}
+	return nil
+}
+
+func RefetchIface(iface *current.Interface) error {
+	link, err := netlink.LinkByName(iface.Name)
+	if err != nil {
+		return fmt.Errorf("failed to refetch interface %s: %v", iface.Name, err)
+	}
+	iface.Mac = link.Attrs().HardwareAddr.String()
 	return nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -30,6 +30,7 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 
@@ -537,4 +538,30 @@ func ExtractInterfaces(args *skel.CmdArgs, result *current.Result, ovsHWOffloadE
 	}
 
 	return hostIntf, contIntf, nil
+}
+
+// ValidateNetnsAttachment validates IPs and routes in the container namespace
+func ValidateNetnsAttachment(args *skel.CmdArgs, result *current.Result, contIntf current.Interface, ovsHWOffloadEnable bool) error {
+	netns, err := ns.GetNS(args.Netns)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	}
+	defer func() { _ = netns.Close() }()
+
+	// Check prevResults for ips and routes against values found in the container
+	return netns.Do(func(_ ns.NetNS) error {
+		// Check interface against values found in the container
+		if err := ValidateInterface(contIntf, false, ovsHWOffloadEnable); err != nil {
+			return err
+		}
+
+		if err := ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs); err != nil {
+			return err
+		}
+
+		if err := ip.ValidateExpectedRoute(result.Routes); err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -21,10 +21,16 @@ import (
 	"log"
 	"net"
 	"sort"
+	"time"
 
+	"github.com/j-keck/arping"
 	"github.com/vishvananda/netlink"
 
+	"github.com/containernetworking/cni/pkg/skel"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ipam"
+	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
@@ -199,4 +205,132 @@ func IPAddrToHWAddr(ip net.IP) net.HardwareAddr {
 
 	hash := sha256.Sum256([]byte(ip.String()))
 	return net.HardwareAddr{0x0A, 0x58, hash[0], hash[1], hash[2], hash[3]}
+}
+
+func waitLinkUp(ovsDriver *ovsdb.OvsBridgeDriver, ofPortName string, retryCount, interval int) error {
+	checkInterval := time.Duration(interval) * time.Millisecond
+	for i := 1; i <= retryCount; i++ {
+		portState, err := ovsDriver.GetOFPortOpState(ofPortName)
+		if err != nil {
+			log.Printf("error in retrieving port %s state: %v", ofPortName, err)
+		} else {
+			if portState == "up" {
+				break
+			}
+		}
+		if i == retryCount {
+			return fmt.Errorf("The OF port %s state is not up, try increasing number of retries/interval config parameter", ofPortName)
+		}
+		time.Sleep(checkInterval)
+	}
+	return nil
+}
+
+func assignMacToLink(link netlink.Link, mac net.HardwareAddr, name string) error {
+	err := netlink.LinkSetHardwareAddr(link, mac)
+	if err != nil {
+		return fmt.Errorf("failed to set container iface %q MAC %q: %v", name, mac.String(), err)
+	}
+	return nil
+}
+
+func ManagedIPAMAddCall(
+	ovsDriver *ovsdb.OvsBridgeDriver,
+	args *skel.CmdArgs,
+	netconf *types.NetConf,
+	mac string,
+	hostIface,
+	contIface *current.Interface,
+	contNetns ns.NetNS,
+	ovsHWOffloadEnabled bool,
+) (*current.Result, error) {
+	var r cnitypes.Result
+	r, err := ipam.ExecAdd(netconf.IPAM.Type, args.StdinData)
+	defer func() {
+		if err != nil {
+			if err := ipam.ExecDel(netconf.IPAM.Type, args.StdinData); err != nil {
+				log.Printf("Failed best-effort cleanup IPAM configuration: %v", err)
+			}
+		}
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up IPAM plugin type %q: %v", netconf.IPAM.Type, err)
+	}
+
+	// Convert the IPAM result into the current Result type
+	var newResult *current.Result
+	newResult, err = current.NewResultFromResult(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(newResult.IPs) == 0 {
+		return nil, errors.New("IPAM plugin returned missing IP config")
+	}
+
+	newResult.Interfaces = []*current.Interface{contIface}
+	newResult.Interfaces[0].Mac = contIface.Mac
+
+	for _, ipc := range newResult.IPs {
+		// All addresses apply to the container interface
+		ipc.Interface = current.Int(0)
+	}
+
+	// wait until OF port link state becomes up. This is needed to make
+	// gratuitous arp for args.IfName to be sent over ovs bridge
+	err = waitLinkUp(ovsDriver, hostIface.Name, netconf.LinkStateCheckRetries, netconf.LinkStateCheckInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	err = contNetns.Do(func(_ ns.NetNS) error {
+		if mac == "" && !ovsHWOffloadEnabled && len(newResult.IPs) >= 1 {
+			containerMac := IPAddrToHWAddr(newResult.IPs[0].Address.IP)
+			containerLink, err := netlink.LinkByName(args.IfName)
+			if err != nil {
+				return fmt.Errorf("failed to lookup container interface %q: %v", args.IfName, err)
+			}
+			err = assignMacToLink(containerLink, containerMac, args.IfName)
+			if err != nil {
+				return err
+			}
+			newResult.Interfaces[0].Mac = containerMac.String()
+		}
+		err := ipam.ConfigureIface(args.IfName, newResult)
+		if err != nil {
+			return err
+		}
+		contVeth, err := net.InterfaceByName(args.IfName)
+		if err != nil {
+			return fmt.Errorf("failed to look up %q: %v", args.IfName, err)
+		}
+		for _, ipc := range newResult.IPs {
+			// if ip address version is 4
+			if ipc.Address.IP.To4() != nil {
+				// send gratuitous arp for other ends to refresh its arp cache
+				err = arping.GratuitousArpOverIface(ipc.Address.IP, *contVeth)
+				if err != nil {
+					// ok to ignore returning this error
+					log.Printf("error sending garp for ip %s: %v", ipc.Address.IP.String(), err)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := newResult
+	result.Interfaces = []*current.Interface{hostIface, result.Interfaces[0]}
+
+	for ifIndex, ifCfg := range result.Interfaces {
+		// Adjust interface index with new container interface index in result.Interfaces
+		if ifCfg.Name == args.IfName {
+			for ipIndex := range result.IPs {
+				result.IPs[ipIndex].Interface = current.Int(ifIndex)
+			}
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -334,3 +334,37 @@ func ManagedIPAMAddCall(
 
 	return result, nil
 }
+
+func ValidateInterface(intf current.Interface, isHost bool, hwOffload bool) error {
+	var link netlink.Link
+	var err error
+	var iftype string
+	if isHost {
+		iftype = "Host"
+	} else {
+		iftype = "Container"
+	}
+
+	if intf.Name == "" {
+		return fmt.Errorf("%s interface name missing in prevResult: %v", iftype, intf.Name)
+	}
+	link, err = netlink.LinkByName(intf.Name)
+	if err != nil {
+		return fmt.Errorf("Error: %s Interface name in prevResult: %s not found", iftype, intf.Name)
+	}
+	if !isHost && intf.Sandbox == "" {
+		return fmt.Errorf("Error: %s interface %s should not be in host namespace", iftype, link.Attrs().Name)
+	}
+	if !hwOffload {
+		_, isVeth := link.(*netlink.Veth)
+		if !isVeth {
+			return fmt.Errorf("Error: %s interface %s not of type veth/p2p", iftype, link.Attrs().Name)
+		}
+	}
+
+	if intf.Mac != "" && intf.Mac != link.Attrs().HardwareAddr.String() {
+		return fmt.Errorf("Error: Interface %s Mac %s doesn't match %s Mac: %s", intf.Name, intf.Mac, iftype, link.Attrs().HardwareAddr)
+	}
+
+	return nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -451,3 +451,27 @@ func ValidateOvs(args *skel.CmdArgs, netconf *types.NetConf, hostIfname string) 
 
 	return nil
 }
+
+func ValidateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
+	if cache.Netconf.BrName != netconf.BrName {
+		return fmt.Errorf("BrName mismatch. cache=%s,netconf=%s",
+			cache.Netconf.BrName, netconf.BrName)
+	}
+
+	if cache.Netconf.SocketFile != netconf.SocketFile {
+		return fmt.Errorf("SocketFile mismatch. cache=%s,netconf=%s",
+			cache.Netconf.SocketFile, netconf.SocketFile)
+	}
+
+	if cache.Netconf.IPAM.Type != netconf.IPAM.Type {
+		return fmt.Errorf("IPAM mismatch. cache=%s,netconf=%s",
+			cache.Netconf.IPAM.Type, netconf.IPAM.Type)
+	}
+
+	if cache.Netconf.DeviceID != netconf.DeviceID {
+		return fmt.Errorf("DeviceID mismatch. cache=%s,netconf=%s",
+			cache.Netconf.DeviceID, netconf.DeviceID)
+	}
+
+	return nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -59,6 +59,12 @@ func GetEnvArgs(envArgsString string) (*types.EnvArgs, error) {
 	return nil, nil
 }
 
+// IsOvsHardwareOffloadEnabled when device id is set, then ovs hardware offload
+// is enabled.
+func IsOvsHardwareOffloadEnabled(deviceID string) bool {
+	return deviceID != ""
+}
+
 func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 	vlans := make(map[uint]bool)
 	for _, item := range trunks {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
@@ -99,4 +100,16 @@ func ParseOvsPortConfig(netconf *types.NetConf) (*OvsPortConfig, error) {
 		Trunks:  trunks,
 		VlanTag: vlanTagNum,
 	}, nil
+}
+
+// GetBridgeName checks the bridgeName and ovnPort variables to resolve
+// bridge name to defaults if needed
+func GetBridgeName(bridgeName, ovnPort string) (string, error) {
+	if bridgeName != "" {
+		return bridgeName, nil
+	} else if bridgeName == "" && ovnPort != "" {
+		return "br-int", nil
+	}
+
+	return "", fmt.Errorf("failed to get bridge name")
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -21,6 +21,17 @@ import (
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
 
+const (
+	portTypeAccess = "access"
+	portTypeTrunk  = "trunk"
+)
+
+type OvsPortConfig struct {
+	Type    string
+	Trunks  []uint
+	VlanTag uint
+}
+
 func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 	vlans := make(map[uint]bool)
 	for _, item := range trunks {
@@ -64,4 +75,28 @@ func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 	}
 	sort.Slice(vlanIds, func(i, j int) bool { return vlanIds[i] < vlanIds[j] })
 	return vlanIds, nil
+}
+
+func ParseOvsPortConfig(netconf *types.NetConf) (*OvsPortConfig, error) {
+	var vlanTagNum uint = 0
+	trunks := make([]uint, 0)
+	portType := portTypeAccess
+	if netconf.VlanTag == nil || len(netconf.Trunk) > 0 {
+		portType = portTypeTrunk
+		if len(netconf.Trunk) > 0 {
+			trunkVlanIds, err := SplitVlanIds(netconf.Trunk)
+			if err != nil {
+				return nil, err
+			}
+			trunks = append(trunks, trunkVlanIds...)
+		}
+	} else if netconf.VlanTag != nil {
+		vlanTagNum = *netconf.VlanTag
+	}
+
+	return &OvsPortConfig{
+		Type:    portType,
+		Trunks:  trunks,
+		VlanTag: vlanTagNum,
+	}, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -145,3 +145,21 @@ func RefetchIface(iface *current.Interface) error {
 	iface.Mac = link.Attrs().HardwareAddr.String()
 	return nil
 }
+
+func AttachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contNetnsPath string, ovnPortName string, contPodUid string) error {
+	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType, intfType, contPodUid)
+	if err != nil {
+		return err
+	}
+
+	hostLink, err := netlink.LinkByName(hostIfaceName)
+	if err != nil {
+		return err
+	}
+
+	if err := netlink.LinkSetUp(hostLink); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
@@ -458,7 +459,7 @@ func ValidateOvs(args *skel.CmdArgs, netconf *types.NetConf, hostIfname string) 
 	return nil
 }
 
-func ValidateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
+func validateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
 	if cache.Netconf.BrName != netconf.BrName {
 		return fmt.Errorf("BrName mismatch. cache=%s,netconf=%s",
 			cache.Netconf.BrName, netconf.BrName)
@@ -480,4 +481,19 @@ func ValidateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
 	}
 
 	return nil
+}
+
+func CacheLoadAndCheck(args *skel.CmdArgs, netconf *types.NetConf) (*types.CachedNetConf, error) {
+	cRef := config.GetCRef(args.ContainerID, args.IfName)
+	cache, err := config.LoadConfFromCache(cRef)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateCache(cache, netconf)
+	if err != nil {
+		return nil, err
+	}
+
+	return cache, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -15,9 +15,11 @@
 package common
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"sort"
 
 	"github.com/vishvananda/netlink"
@@ -181,4 +183,20 @@ func CleanupOvsPortBestEffort(ovsDriver *ovsdb.OvsBridgeDriver, ifaceName string
 	}
 
 	return portName, portFound, nil
+}
+
+// IPAddrToHWAddr takes the four octets of IPv4 address (aa.bb.cc.dd, for example) and uses them in creating
+// a MAC address (0A:58:AA:BB:CC:DD).  For IPv6, create a hash from the IPv6 string and use that for MAC Address.
+// Assumption: the caller will ensure that an empty net.IP{} will NOT be passed.
+// This method is copied from https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/util/net.go
+func IPAddrToHWAddr(ip net.IP) net.HardwareAddr {
+	// Ensure that for IPv4, we are always working with the IP in 4-byte form.
+	ip4 := ip.To4()
+	if ip4 != nil {
+		// safe to use private MAC prefix: 0A:58
+		return net.HardwareAddr{0x0A, 0x58, ip4[0], ip4[1], ip4[2], ip4[3]}
+	}
+
+	hash := sha256.Sum256([]byte(ip.String()))
+	return net.HardwareAddr{0x0A, 0x58, hash[0], hash[1], hash[2], hash[3]}
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -565,3 +565,30 @@ func ValidateNetnsAttachment(args *skel.CmdArgs, result *current.Result, contInt
 		return nil
 	})
 }
+
+// Checks that host and container interfaces are properly configured, as
+// well as the ovs port is assigned to the expected bridge.
+//
+// Bridge name from netconf must be updated with the expected one before
+// calling the function.
+func ValidateAttachment(args *skel.CmdArgs, netconf *types.NetConf, cache *types.CachedNetConf) error {
+	ovsHWOffloadEnable := IsOvsHardwareOffloadEnabled(netconf.DeviceID)
+
+	result, err := ParsePrevResult(netconf)
+	if err != nil {
+		return err
+	}
+
+	hostIntf, contIntf, err := ExtractInterfaces(args, result, ovsHWOffloadEnable)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateNetnsAttachment(args, result, contIntf, ovsHWOffloadEnable)
+	if err != nil {
+		return err
+	}
+
+	// ovs specific check
+	return ValidateOvs(args, netconf, hostIntf.Name)
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -163,3 +163,22 @@ func AttachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string,
 
 	return nil
 }
+
+func RemoveOvsPort(ovsDriver *ovsdb.OvsBridgeDriver, portName string) error {
+	return ovsDriver.DeletePort(portName)
+}
+
+func CleanupOvsPortBestEffort(ovsDriver *ovsdb.OvsBridgeDriver, ifaceName string, contNetns string) (string, bool, error) {
+	portName, portFound, err := ovsDriver.GetOvsPortForContIface(ifaceName, contNetns)
+
+	if err != nil {
+		return "", false, fmt.Errorf("Failed to obtain OVS port for given connection: %v", err)
+	}
+	if portFound {
+		if err := RemoveOvsPort(ovsDriver, portName); err != nil {
+			return portName, portFound, err
+		}
+	}
+
+	return portName, portFound, nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -47,6 +47,18 @@ type OvsPortConfig struct {
 	VlanTag uint
 }
 
+func GetEnvArgs(envArgsString string) (*types.EnvArgs, error) {
+	if envArgsString != "" {
+		e := types.EnvArgs{}
+		err := cnitypes.LoadArgs(envArgsString, &e)
+		if err != nil {
+			return nil, err
+		}
+		return &e, nil
+	}
+	return nil, nil
+}
+
 func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 	vlans := make(map[uint]bool)
 	for _, item := range trunks {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -513,3 +513,28 @@ func ParsePrevResult(netconf *types.NetConf) (*current.Result, error) {
 	}
 	return result, nil
 }
+
+// ExtractInterfaces extracts and validates host and container interfaces from result
+func ExtractInterfaces(args *skel.CmdArgs, result *current.Result, ovsHWOffloadEnable bool) (hostIntf, contIntf current.Interface, err error) {
+	for _, intf := range result.Interfaces {
+		if args.IfName == intf.Name {
+			if args.Netns == intf.Sandbox {
+				contIntf = *intf
+			}
+		} else {
+			// Check prevResults for ips against values found in the host
+			if err := ValidateInterface(*intf, true, ovsHWOffloadEnable); err != nil {
+				return current.Interface{}, current.Interface{}, err
+			}
+			hostIntf = *intf
+		}
+	}
+
+	// The namespace must be the same as what was configured
+	if args.Netns != contIntf.Sandbox {
+		return current.Interface{}, current.Interface{}, fmt.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
+			contIntf.Sandbox, args.Netns)
+	}
+
+	return hostIntf, contIntf, nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -368,3 +368,74 @@ func ValidateInterface(intf current.Interface, isHost bool, hwOffload bool) erro
 
 	return nil
 }
+
+func ValidateOvs(args *skel.CmdArgs, netconf *types.NetConf, hostIfname string) error {
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(netconf.BrName, netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	found, err := ovsBridgeDriver.IsBridgePresent(netconf.BrName)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("Error: bridge %s is not found in OVS", netconf.BrName)
+	}
+
+	hasError, err := ovsBridgeDriver.InterfaceHasError(hostIfname)
+	if err != nil {
+		return err
+	}
+	if hasError {
+		return fmt.Errorf("Error: interface %s is in error state", hostIfname)
+	}
+
+	vlanMode, tag, trunk, err := ovsBridgeDriver.GetOFPortVlanState(hostIfname)
+	if err != nil {
+		return fmt.Errorf("Error: Failed to retrieve port %s state: %v", hostIfname, err)
+	}
+
+	// check vlan tag
+	if netconf.VlanTag == nil {
+		if tag != nil {
+			return fmt.Errorf("vlan tag mismatch. ovs=%d,netconf=nil", *tag)
+		}
+	} else {
+		if tag == nil {
+			return fmt.Errorf("vlan tag mismatch. ovs=nil,netconf=%d", *netconf.VlanTag)
+		}
+		if *tag != *netconf.VlanTag {
+			return fmt.Errorf("vlan tag mismatch. ovs=%d,netconf=%d", *tag, *netconf.VlanTag)
+		}
+		if vlanMode != "access" {
+			return fmt.Errorf("vlan mode mismatch. expected=access,real=%s", vlanMode)
+		}
+	}
+
+	// check trunk
+	netconfTrunks := make([]uint, 0)
+	if len(netconf.Trunk) > 0 {
+		trunkVlanIds, err := SplitVlanIds(netconf.Trunk)
+		if err != nil {
+			return err
+		}
+		netconfTrunks = append(netconfTrunks, trunkVlanIds...)
+	}
+	if len(trunk) != len(netconfTrunks) {
+		return fmt.Errorf("trunk mismatch. ovs=%v,netconf=%v", trunk, netconfTrunks)
+	}
+	if len(netconfTrunks) > 0 {
+		for i := 0; i < len(trunk); i++ {
+			if trunk[i] != netconfTrunks[i] {
+				return fmt.Errorf("trunk mismatch. ovs=%v,netconf=%v", trunk, netconfTrunks)
+			}
+		}
+
+		if vlanMode != "trunk" {
+			return fmt.Errorf("vlan mode mismatch. expected=trunk,real=%s", vlanMode)
+		}
+	}
+
+	return nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,67 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This package collects routines that plugins might need to use no
+// matter the interface backend (veth, sriov vf, userspace...)
+package common
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+)
+
+func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
+	vlans := make(map[uint]bool)
+	for _, item := range trunks {
+		var minID uint = 0
+		var maxID uint = 0
+		if item.MinID != nil {
+			minID = *item.MinID
+			if minID > 4096 {
+				return nil, errors.New("incorrect trunk minID parameter")
+			}
+		}
+		if item.MaxID != nil {
+			maxID = *item.MaxID
+			if maxID > 4096 {
+				return nil, errors.New("incorrect trunk maxID parameter")
+			}
+			if maxID < minID {
+				return nil, errors.New("minID is greater than maxID in trunk parameter")
+			}
+		}
+		if minID > 0 && maxID > 0 {
+			for v := minID; v <= maxID; v++ {
+				vlans[v] = true
+			}
+		}
+		var id uint
+		if item.ID != nil {
+			id = *item.ID
+			if minID > 4096 {
+				return nil, errors.New("incorrect trunk id parameter")
+			}
+			vlans[id] = true
+		}
+	}
+	if len(vlans) == 0 {
+		return nil, errors.New("trunk parameter is misconfigured")
+	}
+	vlanIds := make([]uint, 0, len(vlans))
+	for k := range vlans {
+		vlanIds = append(vlanIds, k)
+	}
+	sort.Slice(vlanIds, func(i, j int) bool { return vlanIds[i] < vlanIds[j] })
+	return vlanIds, nil
+}

--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,81 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+)
+
+var _ = Describe("", func() {
+	testSplitVlanIds := func(conf string, expTrunks []uint, expErr error, setUnmarshalErr bool) {
+		var trunks []*types.Trunk
+		err := json.Unmarshal([]byte(conf), &trunks)
+		if setUnmarshalErr {
+			Expect(err).To(HaveOccurred())
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+		By("Calling testSplitVlanIds method")
+		vlanIds, err := SplitVlanIds(trunks)
+		if expErr != nil {
+			By("Checking expected error is occurred")
+			Expect(err).To(Equal(expErr))
+		} else {
+			By("Checking vlanIds are same as trunk vlans")
+			Expect(vlanIds).To(Equal(expTrunks))
+		}
+	}
+
+	Context("specify trunk with multiple ranges", func() {
+		trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 19, "maxID": 20} ]`
+		It("testSplitVlanIds method should return with specified values in the range", func() {
+			testSplitVlanIds(trunks, []uint{10, 11, 12, 19, 20}, nil, false)
+		})
+	})
+	Context("specify trunk with multiple ids", func() {
+		trunks := `[ {"id": 15}, {"id": 19}, {"id": 40} ]`
+		It("testSplitVlanIds method should return with specified id values", func() {
+			testSplitVlanIds(trunks, []uint{15, 19, 40}, nil, false)
+		})
+	})
+	Context("specify trunk with minID/maxID same value and duplicate values", func() {
+		trunks := `[ {"minID": 10, "maxID": 14}, {"id": 11}, {"minID": 13, "maxID": 13} ]`
+		It("testSplitVlanIds method should return without duplicate trunk values", func() {
+			testSplitVlanIds(trunks, []uint{10, 11, 12, 13, 14}, nil, false)
+		})
+	})
+	Context("specify trunk with negative value", func() {
+		trunks := `[ {"id": 15}, {"id": 15}, {"id": -20} ]`
+		It("testSplitVlanIds method should throw appropriate error", func() {
+			testSplitVlanIds(trunks, nil, errors.New("incorrect trunk id parameter"), true)
+		})
+	})
+	Context("specify trunk with minID greater than maxID", func() {
+		trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 11, "maxID": 5} ]`
+		It("testSplitVlanIds method should throw appropriate error", func() {
+			testSplitVlanIds(trunks, nil, errors.New("minID is greater than maxID in trunk parameter"), false)
+		})
+	})
+	Context("specify trunk with maxID greater than 4096", func() {
+		trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 1, "maxID": 5000} ]`
+		It("testSplitVlanIds method should throw appropriate error", func() {
+			testSplitVlanIds(trunks, nil, errors.New("incorrect trunk maxID parameter"), false)
+		})
+	})
+})

--- a/pkg/deviceinfo/deviceinfo.go
+++ b/pkg/deviceinfo/deviceinfo.go
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deviceinfo
+
+import (
+	"encoding/json"
+	"os"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+)
+
+const RootDeviceInfoDirectory = "/var/run/k8s.cni.cncf.io/devinfo/cni"
+
+func readDeviceInfo(devInfoPath string) (*netv1.DeviceInfo, error) {
+	devInfoBytes, err := os.ReadFile(devInfoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var deviceInfo netv1.DeviceInfo
+	err = json.Unmarshal(devInfoBytes, &deviceInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deviceInfo, nil
+}
+
+func GetDeviceInfo(netconf *types.NetConf) (*netv1.DeviceInfo, error) {
+	if netconf.RuntimeConfig == nil || netconf.RuntimeConfig.CNIDeviceInfoFile == "" {
+		return nil, nil
+	}
+
+	return readDeviceInfo(netconf.RuntimeConfig.CNIDeviceInfoFile)
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -45,6 +45,7 @@ import (
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/vdpa"
 )
 
 const (
@@ -344,14 +345,28 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	vdpaDev, err := vdpa.GetVdpaDeviceFromID(netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+	vdpaDevType, err := vdpa.GetDeviceType(vdpaDev)
+	if err != nil {
+		return err
+	}
+
 	// Cache NetConf for CmdDel
 	if err = utils.SaveCache(config.GetCRef(args.ContainerID, args.IfName),
-		&types.CachedNetConf{Netconf: netconf, OrigIfName: origIfName, UserspaceMode: userspaceMode}); err != nil {
+		&types.CachedNetConf{Netconf: netconf, OrigIfName: origIfName, UserspaceMode: userspaceMode, VdpaType: vdpaDevType}); err != nil {
 		return fmt.Errorf("error saving NetConf %q", err)
 	}
 
 	var hostIface, contIface *current.Interface
-	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+	if vdpaDevType == types.VdpaDeviceTypeKernelVhost {
+		hostIface, contIface, err = vdpa.SetupVdpaInterface(contNetns, args.IfName, netconf.DeviceID, mac, vdpaDev, netconf.MTU)
+		if err != nil {
+			return err
+		}
+	} else if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
 		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, mac, netconf.MTU, netconf.DeviceID, userspaceMode)
 		if err != nil {
 			return err
@@ -389,7 +404,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	// run the IPAM plugin
 	// userspace driver does not support IPAM plugin,
 	// because there is no network interface for the VF on the host
-	if netconf.IPAM.Type != "" && !userspaceMode {
+	if netconf.IPAM.Type != "" && !userspaceMode && vdpaDevType != types.VdpaDeviceTypeKernelVhost {
 		var r cnitypes.Result
 		r, err = ipam.ExecAdd(netconf.IPAM.Type, args.StdinData)
 		defer func() {
@@ -598,7 +613,8 @@ func CmdDel(args *skel.CmdArgs) error {
 				log.Printf("Error: %v\n", err)
 			}
 			// there is no network interface in case of userspace driver, so OrigIfName is empty
-			if !cache.UserspaceMode {
+			// For vhost_vdpa devices backed by sriov mgmtdevs is the same
+			if !cache.UserspaceMode && cache.VdpaType != types.VdpaDeviceTypeKernelVhost {
 				if err = sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
 					return err
 				}
@@ -630,7 +646,8 @@ func CmdDel(args *skel.CmdArgs) error {
 
 	if sriov.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
 		// there is no network interface in case of userspace driver, so OrigIfName is empty
-		if !cache.UserspaceMode {
+		// For vhost_vdpa devices backed by sriov mgmtdevs is the same
+		if !cache.UserspaceMode && cache.VdpaType != types.VdpaDeviceTypeKernelVhost {
 			err = sriov.ReleaseVF(args, cache.OrigIfName)
 			if err != nil {
 				// try to reset vf into original state as much as possible in case of error

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -730,7 +730,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	// run the IPAM plugin
 	// userspace driver does not support IPAM plugin,
 	// because there is no network interface for the VF on the host
-	if netconf.NetConf.IPAM.Type != "" && !cache.UserspaceMode {
+	if netconf.NetConf.IPAM.Type != "" && !cache.UserspaceMode && cache.VdpaType != types.VdpaDeviceTypeKernelVhost {
 		err = ipam.ExecCheck(netconf.NetConf.IPAM.Type, args.StdinData)
 		if err != nil {
 			return fmt.Errorf("failed to check with IPAM plugin type %q: %v", netconf.NetConf.IPAM.Type, err)
@@ -771,32 +771,39 @@ func CmdCheck(args *skel.CmdArgs) error {
 			contIntf.Sandbox, args.Netns)
 	}
 
-	netns, err := ns.GetNS(args.Netns)
-	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
-	}
-	defer func() { _ = netns.Close() }()
+	if cache.VdpaType != types.VdpaDeviceTypeKernelVhost {
+		netns, err := ns.GetNS(args.Netns)
+		if err != nil {
+			return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+		}
+		defer func() { _ = netns.Close() }()
 
-	// Check prevResults for ips and routes against values found in the container
-	if err := netns.Do(func(_ ns.NetNS) error {
-		// Check interface against values found in the container
-		err := validateInterface(contIntf, false, ovsHWOffloadEnable)
+		// Check prevResults for ips and routes against values found in the container
+		if err := netns.Do(func(_ ns.NetNS) error {
+			// Check interface against values found in the container
+			err := validateInterface(contIntf, false, ovsHWOffloadEnable)
+			if err != nil {
+				return err
+			}
+
+			err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
+			if err != nil {
+				return err
+			}
+
+			err = ip.ValidateExpectedRoute(result.Routes)
+			if err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	} else {
+		err := vdpa.ValidateVdpaDevice(contIntf, netconf.DeviceID, cache.VdpaType)
 		if err != nil {
 			return err
 		}
-
-		err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
-		if err != nil {
-			return err
-		}
-
-		err = ip.ValidateExpectedRoute(result.Routes)
-		if err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	// ovs specific check

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -349,13 +349,8 @@ func CmdCheck(args *skel.CmdArgs) error {
 	netconf.BrName = bridgeName
 
 	// check cache
-	cRef := config.GetCRef(args.ContainerID, args.IfName)
-	cache, err := config.LoadConfFromCache(cRef)
+	cache, err := common.CacheLoadAndCheck(args, netconf)
 	if err != nil {
-		return err
-	}
-
-	if err := common.ValidateCache(cache, netconf); err != nil {
 		return err
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -205,14 +205,9 @@ func CmdAdd(args *skel.CmdArgs) error {
 		if err != nil {
 			// Unlike veth pair, OVS port will not be automatically removed
 			// if the following IPAM configuration fails and netns gets removed.
-			portName, portFound, err := getOvsPortForContIface(ovsBridgeDriver, args.IfName, args.Netns)
+			_, _, err = common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
 			if err != nil {
 				log.Printf("Failed best-effort cleanup: %v", err)
-			}
-			if portFound {
-				if err := removeOvsPort(ovsBridgeDriver, portName); err != nil {
-					log.Printf("Failed best-effort cleanup: %v", err)
-				}
 			}
 		}
 	}()
@@ -336,15 +331,6 @@ func waitLinkUp(ovsDriver *ovsdb.OvsBridgeDriver, ofPortName string, retryCount,
 	return nil
 }
 
-func getOvsPortForContIface(ovsDriver *ovsdb.OvsBridgeDriver, contIface string, contNetnsPath string) (string, bool, error) {
-	// External IDs were set on the port during ADD call.
-	return ovsDriver.GetOvsPortForContIface(contIface, contNetnsPath)
-}
-
-func removeOvsPort(ovsDriver *ovsdb.OvsBridgeDriver, portName string) error {
-	return ovsDriver.DeletePort(portName)
-}
-
 // CmdDel remove handler for deleting container from network
 func CmdDel(args *skel.CmdArgs) error {
 	logCall("DEL", args)
@@ -410,7 +396,7 @@ func CmdDel(args *skel.CmdArgs) error {
 			if rep, err = sriov.GetNetRepresentor(cache.Netconf.DeviceID); err != nil {
 				return err
 			}
-			if err = removeOvsPort(ovsBridgeDriver, rep); err != nil {
+			if err = common.RemoveOvsPort(ovsBridgeDriver, rep); err != nil {
 				// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
 				// port is already deleted in a previous invocation.
 				log.Printf("Error: %v\n", err)
@@ -433,17 +419,9 @@ func CmdDel(args *skel.CmdArgs) error {
 	// Unlike veth pair, OVS port will not be automatically removed when
 	// container namespace is gone. Find port matching DEL arguments and remove
 	// it explicitly.
-	portName, portFound, err := getOvsPortForContIface(ovsBridgeDriver, args.IfName, args.Netns)
+	portName, portFound, err := common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
 	if err != nil {
-		return fmt.Errorf("Failed to obtain OVS port for given connection: %v", err)
-	}
-
-	// Do not return an error if the port was not found, it may have been
-	// already removed by someone.
-	if portFound {
-		if err := removeOvsPort(ovsBridgeDriver, portName); err != nil {
-			return err
-		}
+		return err
 	}
 
 	if sriov.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -143,32 +143,6 @@ func assignMacToLink(link netlink.Link, mac net.HardwareAddr, name string) error
 	return nil
 }
 
-func getBridgeName(driver *ovsdb.OvsDriver, bridgeName, ovnPort, deviceID string) (string, error) {
-	if bridgeName != "" {
-		return bridgeName, nil
-	} else if bridgeName == "" && ovnPort != "" {
-		return "br-int", nil
-	} else if deviceID != "" {
-		possibleUplinkNames, err := sriov.GetBridgeUplinkNameByDeviceID(deviceID)
-		if err != nil {
-			return "", fmt.Errorf("failed to get bridge name - failed to resolve uplink name: %v", err)
-		}
-		var errList []error
-		for _, uplinkName := range possibleUplinkNames {
-			bridgeName, err = driver.FindBridgeByInterface(uplinkName)
-			if err != nil {
-				errList = append(errList,
-					fmt.Errorf("failed to get bridge name - failed to find bridge name by uplink name %s: %v", uplinkName, err))
-				continue
-			}
-			return bridgeName, nil
-		}
-		return "", fmt.Errorf("failed to find bridge by uplink names %v: %v", possibleUplinkNames, errList)
-	}
-
-	return "", fmt.Errorf("failed to get bridge name")
-}
-
 func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contNetnsPath string, ovnPortName string, contPodUid string) error {
 	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType, intfType, contPodUid)
 	if err != nil {
@@ -228,7 +202,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	bridgeName, err := getBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
+	bridgeName, err := sriov.GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
 	if err != nil {
 		return err
 	}
@@ -500,7 +474,7 @@ func CmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	bridgeName, err := getBridgeName(ovsDriver, cache.Netconf.BrName, ovnPort, cache.Netconf.DeviceID)
+	bridgeName, err := sriov.GetBridgeName(ovsDriver, cache.Netconf.BrName, ovnPort, cache.Netconf.DeviceID)
 	if err != nil {
 		return err
 	}
@@ -623,7 +597,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	}
 	// cached config may contain bridge name which were automatically
 	// discovered in CmdAdd, we need to re-discover the bridge name before we validating the cache
-	bridgeName, err := getBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
+	bridgeName, err := sriov.GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -449,7 +449,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	}
 
 	// ovs specific check
-	if err := ValidateOvs(args, netconf, hostIntf.Name); err != nil {
+	if err := common.ValidateOvs(args, netconf, hostIntf.Name); err != nil {
 		return err
 	}
 
@@ -475,77 +475,6 @@ func validateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
 	if cache.Netconf.DeviceID != netconf.DeviceID {
 		return fmt.Errorf("DeviceID mismatch. cache=%s,netconf=%s",
 			cache.Netconf.DeviceID, netconf.DeviceID)
-	}
-
-	return nil
-}
-
-func ValidateOvs(args *skel.CmdArgs, netconf *types.NetConf, hostIfname string) error {
-	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(netconf.BrName, netconf.SocketFile)
-	if err != nil {
-		return err
-	}
-
-	found, err := ovsBridgeDriver.IsBridgePresent(netconf.BrName)
-	if err != nil {
-		return err
-	}
-	if !found {
-		return fmt.Errorf("Error: bridge %s is not found in OVS", netconf.BrName)
-	}
-
-	hasError, err := ovsBridgeDriver.InterfaceHasError(hostIfname)
-	if err != nil {
-		return err
-	}
-	if hasError {
-		return fmt.Errorf("Error: interface %s is in error state", hostIfname)
-	}
-
-	vlanMode, tag, trunk, err := ovsBridgeDriver.GetOFPortVlanState(hostIfname)
-	if err != nil {
-		return fmt.Errorf("Error: Failed to retrieve port %s state: %v", hostIfname, err)
-	}
-
-	// check vlan tag
-	if netconf.VlanTag == nil {
-		if tag != nil {
-			return fmt.Errorf("vlan tag mismatch. ovs=%d,netconf=nil", *tag)
-		}
-	} else {
-		if tag == nil {
-			return fmt.Errorf("vlan tag mismatch. ovs=nil,netconf=%d", *netconf.VlanTag)
-		}
-		if *tag != *netconf.VlanTag {
-			return fmt.Errorf("vlan tag mismatch. ovs=%d,netconf=%d", *tag, *netconf.VlanTag)
-		}
-		if vlanMode != "access" {
-			return fmt.Errorf("vlan mode mismatch. expected=access,real=%s", vlanMode)
-		}
-	}
-
-	// check trunk
-	netconfTrunks := make([]uint, 0)
-	if len(netconf.Trunk) > 0 {
-		trunkVlanIds, err := common.SplitVlanIds(netconf.Trunk)
-		if err != nil {
-			return err
-		}
-		netconfTrunks = append(netconfTrunks, trunkVlanIds...)
-	}
-	if len(trunk) != len(netconfTrunks) {
-		return fmt.Errorf("trunk mismatch. ovs=%v,netconf=%v", trunk, netconfTrunks)
-	}
-	if len(netconfTrunks) > 0 {
-		for i := 0; i < len(trunk); i++ {
-			if trunk[i] != netconfTrunks[i] {
-				return fmt.Errorf("trunk mismatch. ovs=%v,netconf=%v", trunk, netconfTrunks)
-			}
-		}
-
-		if vlanMode != "trunk" {
-			return fmt.Errorf("vlan mode mismatch. expected=trunk,real=%s", vlanMode)
-		}
 	}
 
 	return nil

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -45,6 +45,7 @@ import (
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/veth"
 )
 
 func init() {
@@ -85,54 +86,6 @@ func IPAddrToHWAddr(ip net.IP) net.HardwareAddr {
 
 	hash := sha256.Sum256([]byte(ip.String()))
 	return net.HardwareAddr{0x0A, 0x58, hash[0], hash[1], hash[2], hash[3]}
-}
-
-func setupVeth(contNetns ns.NetNS, contIfaceName string, requestedMac string, mtu int) (*current.Interface, *current.Interface, error) {
-	hostIface := &current.Interface{}
-	contIface := &current.Interface{}
-
-	// Enter container network namespace and create veth pair inside. Doing
-	// this we will make sure that both ends of the veth pair will be removed
-	// when the container is gone.
-	err := contNetns.Do(func(hostNetns ns.NetNS) error {
-		hostVeth, containerVeth, err := ip.SetupVeth(contIfaceName, mtu, requestedMac, hostNetns)
-		if err != nil {
-			return err
-		}
-
-		if err := setInterfaceUp(contIfaceName); err != nil {
-			return err
-		}
-
-		contIface.Name = containerVeth.Name
-		contIface.Mac = containerVeth.HardwareAddr.String()
-		contIface.Sandbox = contNetns.Path()
-		hostIface.Name = hostVeth.Name
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Refetch the hostIface since its MAC address may change during network namespace move.
-	if err = common.RefetchIface(hostIface); err != nil {
-		return nil, nil, err
-	}
-
-	return hostIface, contIface, nil
-}
-
-func setInterfaceUp(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-
-	if err := netlink.LinkSetUp(link); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func assignMacToLink(link netlink.Link, mac net.HardwareAddr, name string) error {
@@ -250,7 +203,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 			return err
 		}
 	} else {
-		hostIface, contIface, err = setupVeth(contNetns, args.IfName, mac, netconf.MTU)
+		hostIface, contIface, err = veth.SetupVeth(contNetns, args.IfName, mac, netconf.MTU)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -76,6 +76,10 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if !common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+		return veth.CmdAdd(args, netconf)
+	}
+
 	portCfg, err := common.ParseOvsPortConfig(netconf)
 	if err != nil {
 		return err
@@ -138,11 +142,6 @@ func CmdAdd(args *skel.CmdArgs) error {
 	var hostIface, contIface *current.Interface
 	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
 		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, mac, netconf.MTU, netconf.DeviceID, userspaceMode)
-		if err != nil {
-			return err
-		}
-	} else {
-		hostIface, contIface, err = veth.SetupVeth(contNetns, args.IfName, mac, netconf.MTU)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -378,32 +378,10 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
-	netns, err := ns.GetNS(args.Netns)
-	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
-	}
-	defer func() { _ = netns.Close() }()
-
 	// Check prevResults for ips and routes against values found in the container
-	if err := netns.Do(func(_ ns.NetNS) error {
-		// Check interface against values found in the container
-		err := common.ValidateInterface(contIntf, false, ovsHWOffloadEnable)
-		if err != nil {
-			return err
-		}
-
-		err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
-		if err != nil {
-			return err
-		}
-
-		err = ip.ValidateExpectedRoute(result.Routes)
-		if err != nil {
-			return err
-		}
+	err = common.ValidateNetnsAttachment(args, result, contIntf, ovsHWOffloadEnable)
+	if err != nil {
 		return nil
-	}); err != nil {
-		return err
 	}
 
 	// ovs specific check

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -27,7 +27,6 @@ import (
 	"log"
 	"net"
 	"runtime"
-	"sort"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -40,6 +39,7 @@ import (
 	"github.com/j-keck/arping"
 	"github.com/vishvananda/netlink"
 
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
@@ -201,51 +201,6 @@ func refetchIface(iface *current.Interface) error {
 	return nil
 }
 
-func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
-	vlans := make(map[uint]bool)
-	for _, item := range trunks {
-		var minID uint = 0
-		var maxID uint = 0
-		if item.MinID != nil {
-			minID = *item.MinID
-			if minID > 4096 {
-				return nil, errors.New("incorrect trunk minID parameter")
-			}
-		}
-		if item.MaxID != nil {
-			maxID = *item.MaxID
-			if maxID > 4096 {
-				return nil, errors.New("incorrect trunk maxID parameter")
-			}
-			if maxID < minID {
-				return nil, errors.New("minID is greater than maxID in trunk parameter")
-			}
-		}
-		if minID > 0 && maxID > 0 {
-			for v := minID; v <= maxID; v++ {
-				vlans[v] = true
-			}
-		}
-		var id uint
-		if item.ID != nil {
-			id = *item.ID
-			if minID > 4096 {
-				return nil, errors.New("incorrect trunk id parameter")
-			}
-			vlans[id] = true
-		}
-	}
-	if len(vlans) == 0 {
-		return nil, errors.New("trunk parameter is misconfigured")
-	}
-	vlanIds := make([]uint, 0, len(vlans))
-	for k := range vlans {
-		vlanIds = append(vlanIds, k)
-	}
-	sort.Slice(vlanIds, func(i, j int) bool { return vlanIds[i] < vlanIds[j] })
-	return vlanIds, nil
-}
-
 // CmdAdd add handler for attaching container into network
 func CmdAdd(args *skel.CmdArgs) error {
 	logCall("ADD", args)
@@ -275,7 +230,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	if netconf.VlanTag == nil || len(netconf.Trunk) > 0 {
 		portType = portTypeTrunk
 		if len(netconf.Trunk) > 0 {
-			trunkVlanIds, err := SplitVlanIds(netconf.Trunk)
+			trunkVlanIds, err := common.SplitVlanIds(netconf.Trunk)
 			if err != nil {
 				return err
 			}
@@ -890,7 +845,7 @@ func ValidateOvs(args *skel.CmdArgs, netconf *types.NetConf, hostIfname string) 
 	// check trunk
 	netconfTrunks := make([]uint, 0)
 	if len(netconf.Trunk) > 0 {
-		trunkVlanIds, err := SplitVlanIds(netconf.Trunk)
+		trunkVlanIds, err := common.SplitVlanIds(netconf.Trunk)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -309,6 +309,10 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if !common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+		return veth.CmdCheck(args, netconf)
+	}
+
 	envArgs, err := common.GetEnvArgs(args.Args)
 	if err != nil {
 		return err
@@ -317,6 +321,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+
 	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
 	if err != nil {
 		return err

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -313,47 +313,5 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return veth.CmdCheck(args, netconf)
 	}
 
-	envArgs, err := common.GetEnvArgs(args.Args)
-	if err != nil {
-		return err
-	}
-	var ovnPort string
-	if envArgs != nil {
-		ovnPort = string(envArgs.OvnPort)
-	}
-
-	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
-	if err != nil {
-		return err
-	}
-	// cached config may contain bridge name which were automatically
-	// discovered in CmdAdd, we need to re-discover the bridge name before we validating the cache
-	bridgeName, err := sriov.GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
-	if err != nil {
-		return err
-	}
-	netconf.BrName = bridgeName
-
-	// check cache
-	cache, err := common.CacheLoadAndCheck(args, netconf)
-	if err != nil {
-		return err
-	}
-
-	// TODO: CmdCheck for userspace driver
-	if cache.UserspaceMode {
-		return nil
-	}
-
-	// run the IPAM plugin
-	// userspace driver does not support IPAM plugin,
-	// because there is no network interface for the VF on the host
-	if netconf.NetConf.IPAM.Type != "" && !cache.UserspaceMode {
-		err = ipam.ExecCheck(netconf.NetConf.IPAM.Type, args.StdinData)
-		if err != nil {
-			return fmt.Errorf("failed to check with IPAM plugin type %q: %v", netconf.NetConf.IPAM.Type, err)
-		}
-	}
-
-	return common.ValidateAttachment(args, netconf, cache)
+	return sriov.CmdCheck(args, netconf)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -54,23 +54,11 @@ func logCall(command string, args *skel.CmdArgs) {
 		command, args.ContainerID, args.Netns, args.IfName, string(args.StdinData[:]))
 }
 
-func getEnvArgs(envArgsString string) (*types.EnvArgs, error) {
-	if envArgsString != "" {
-		e := types.EnvArgs{}
-		err := cnitypes.LoadArgs(envArgsString, &e)
-		if err != nil {
-			return nil, err
-		}
-		return &e, nil
-	}
-	return nil, nil
-}
-
 // CmdAdd add handler for attaching container into network
 func CmdAdd(args *skel.CmdArgs) error {
 	logCall("ADD", args)
 
-	envArgs, err := getEnvArgs(args.Args)
+	envArgs, err := common.GetEnvArgs(args.Args)
 	if err != nil {
 		return err
 	}
@@ -226,7 +214,7 @@ func CmdDel(args *skel.CmdArgs) error {
 		}
 	}()
 
-	envArgs, err := getEnvArgs(args.Args)
+	envArgs, err := common.GetEnvArgs(args.Args)
 	if err != nil {
 		return err
 	}
@@ -340,7 +328,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	}
 	ovsHWOffloadEnable := sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID)
 
-	envArgs, err := getEnvArgs(args.Args)
+	envArgs, err := common.GetEnvArgs(args.Args)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 
@@ -217,6 +216,11 @@ func CmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if !common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
+		err = veth.CmdDel(args, cache)
+		return err
+	}
+
 	var ovnPort string
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
@@ -263,11 +267,6 @@ func CmdDel(args *skel.CmdArgs) error {
 					return err
 				}
 			}
-		} else {
-			// In accordance with the spec we clean up as many resources as possible.
-			if err := common.CleanPorts(ovsBridgeDriver); err != nil {
-				return err
-			}
 		}
 		return nil
 	}
@@ -275,7 +274,7 @@ func CmdDel(args *skel.CmdArgs) error {
 	// Unlike veth pair, OVS port will not be automatically removed when
 	// container namespace is gone. Find port matching DEL arguments and remove
 	// it explicitly.
-	portName, portFound, err := common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+	_, _, err = common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
 	if err != nil {
 		return err
 	}
@@ -290,21 +289,6 @@ func CmdDel(args *skel.CmdArgs) error {
 					log.Printf("Failed best-effort cleanup of VF %s: %v", cache.OrigIfName, err)
 				}
 			}
-		}
-	} else {
-		err = ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {
-			err = ip.DelLinkByName(args.IfName)
-			return err
-		})
-		// do the following as per cni spec (i.e. Plugins should generally complete a DEL action
-		// without error even if some resources are missing)
-		if _, ok := err.(ns.NSPathNotExistErr); ok || err == ip.ErrLinkNotFound {
-			if portFound {
-				if err := ip.DelLinkByName(portName); err != nil {
-					log.Printf("Failed best-effort cleanup of %s: %v", portName, err)
-				}
-			}
-			return nil
 		}
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -103,7 +103,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	// check if the device driver is the type of userspace driver
 	userspaceMode := false
-	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
 		userspaceMode, err = sriov.HasUserspaceDriver(netconf.DeviceID)
 		if err != nil {
 			return err
@@ -123,7 +123,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	// userspace driver does not create a network interface for the VF on the host
 	var origIfName string
-	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) && !userspaceMode {
+	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) && !userspaceMode {
 		origIfName, err = sriov.GetVFLinkName(netconf.DeviceID)
 		if err != nil {
 			return err
@@ -137,7 +137,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	var hostIface, contIface *current.Interface
-	if sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
+	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
 		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, mac, netconf.MTU, netconf.DeviceID, userspaceMode)
 		if err != nil {
 			return err
@@ -179,7 +179,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	// because there is no network interface for the VF on the host
 	if netconf.IPAM.Type != "" && !userspaceMode {
 		result, err = common.ManagedIPAMAddCall(
-			ovsBridgeDriver, args, netconf, mac, hostIface, contIface, contNetns, sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID),
+			ovsBridgeDriver, args, netconf, mac, hostIface, contIface, contNetns, common.IsOvsHardwareOffloadEnabled(netconf.DeviceID),
 		)
 		if err != nil {
 			return err
@@ -247,7 +247,7 @@ func CmdDel(args *skel.CmdArgs) error {
 	if args.Netns == "" {
 		// The CNI_NETNS parameter may be empty according to version 0.4.0
 		// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
-		if sriov.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
+		if common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
 			// SR-IOV Case - The sriov device is moved into host network namespace when args.Netns is empty.
 			// This happens container is killed due to an error (example: CrashLoopBackOff, OOMKilled)
 			var rep string
@@ -282,7 +282,7 @@ func CmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if sriov.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
+	if common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
 		// there is no network interface in case of userspace driver, so OrigIfName is empty
 		if !cache.UserspaceMode {
 			err = sriov.ReleaseVF(args, cache.OrigIfName)
@@ -326,7 +326,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	ovsHWOffloadEnable := sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID)
+	ovsHWOffloadEnable := common.IsOvsHardwareOffloadEnabled(netconf.DeviceID)
 
 	envArgs, err := common.GetEnvArgs(args.Args)
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -96,24 +96,6 @@ func assignMacToLink(link netlink.Link, mac net.HardwareAddr, name string) error
 	return nil
 }
 
-func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string, contIfaceName string, ofportRequest uint, vlanTag uint, trunks []uint, portType string, intfType string, contNetnsPath string, ovnPortName string, contPodUid string) error {
-	err := ovsDriver.CreatePort(hostIfaceName, contNetnsPath, contIfaceName, ovnPortName, ofportRequest, vlanTag, trunks, portType, intfType, contPodUid)
-	if err != nil {
-		return err
-	}
-
-	hostLink, err := netlink.LinkByName(hostIfaceName)
-	if err != nil {
-		return err
-	}
-
-	if err := netlink.LinkSetUp(hostLink); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // CmdAdd add handler for attaching container into network
 func CmdAdd(args *skel.CmdArgs) error {
 	logCall("ADD", args)
@@ -209,7 +191,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	if err = attachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, portCfg.VlanTag, portCfg.Trunks, portCfg.Type, netconf.InterfaceType, args.Netns, ovnPort, contPodUid); err != nil {
+	if err = common.AttachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, portCfg.VlanTag, portCfg.Trunks, portCfg.Type, netconf.InterfaceType, args.Netns, ovnPort, contPodUid); err != nil {
 		return err
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -21,7 +21,6 @@
 package plugin
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log"
@@ -70,22 +69,6 @@ func getEnvArgs(envArgsString string) (*types.EnvArgs, error) {
 		return &e, nil
 	}
 	return nil, nil
-}
-
-// IPAddrToHWAddr takes the four octets of IPv4 address (aa.bb.cc.dd, for example) and uses them in creating
-// a MAC address (0A:58:AA:BB:CC:DD).  For IPv6, create a hash from the IPv6 string and use that for MAC Address.
-// Assumption: the caller will ensure that an empty net.IP{} will NOT be passed.
-// This method is copied from https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/util/net.go
-func IPAddrToHWAddr(ip net.IP) net.HardwareAddr {
-	// Ensure that for IPv4, we are always working with the IP in 4-byte form.
-	ip4 := ip.To4()
-	if ip4 != nil {
-		// safe to use private MAC prefix: 0A:58
-		return net.HardwareAddr{0x0A, 0x58, ip4[0], ip4[1], ip4[2], ip4[3]}
-	}
-
-	hash := sha256.Sum256([]byte(ip.String()))
-	return net.HardwareAddr{0x0A, 0x58, hash[0], hash[1], hash[2], hash[3]}
 }
 
 func assignMacToLink(link netlink.Link, mac net.HardwareAddr, name string) error {
@@ -261,7 +244,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 		err = contNetns.Do(func(_ ns.NetNS) error {
 			if mac == "" && !sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) && len(newResult.IPs) >= 1 {
-				containerMac := IPAddrToHWAddr(newResult.IPs[0].Address.IP)
+				containerMac := common.IPAddrToHWAddr(newResult.IPs[0].Address.IP)
 				containerLink, err := netlink.LinkByName(args.IfName)
 				if err != nil {
 					return fmt.Errorf("failed to lookup container interface %q: %v", args.IfName, err)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -21,12 +21,9 @@
 package plugin
 
 import (
-	"errors"
 	"fmt"
 	"log"
-	"net"
 	"runtime"
-	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -35,7 +32,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/j-keck/arping"
 	"github.com/vishvananda/netlink"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
@@ -69,14 +65,6 @@ func getEnvArgs(envArgsString string) (*types.EnvArgs, error) {
 		return &e, nil
 	}
 	return nil, nil
-}
-
-func assignMacToLink(link netlink.Link, mac net.HardwareAddr, name string) error {
-	err := netlink.LinkSetHardwareAddr(link, mac)
-	if err != nil {
-		return fmt.Errorf("failed to set container iface %q MAC %q: %v", name, mac.String(), err)
-	}
-	return nil
 }
 
 // CmdAdd add handler for attaching container into network
@@ -203,115 +191,15 @@ func CmdAdd(args *skel.CmdArgs) error {
 	// userspace driver does not support IPAM plugin,
 	// because there is no network interface for the VF on the host
 	if netconf.IPAM.Type != "" && !userspaceMode {
-		var r cnitypes.Result
-		r, err = ipam.ExecAdd(netconf.IPAM.Type, args.StdinData)
-		defer func() {
-			if err != nil {
-				if err := ipam.ExecDel(netconf.IPAM.Type, args.StdinData); err != nil {
-					log.Printf("Failed best-effort cleanup IPAM configuration: %v", err)
-				}
-			}
-		}()
-		if err != nil {
-			return fmt.Errorf("failed to set up IPAM plugin type %q: %v", netconf.IPAM.Type, err)
-		}
-
-		// Convert the IPAM result into the current Result type
-		var newResult *current.Result
-		newResult, err = current.NewResultFromResult(r)
+		result, err = common.ManagedIPAMAddCall(
+			ovsBridgeDriver, args, netconf, mac, hostIface, contIface, contNetns, sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID),
+		)
 		if err != nil {
 			return err
-		}
-
-		if len(newResult.IPs) == 0 {
-			return errors.New("IPAM plugin returned missing IP config")
-		}
-
-		newResult.Interfaces = []*current.Interface{contIface}
-		newResult.Interfaces[0].Mac = contIface.Mac
-
-		for _, ipc := range newResult.IPs {
-			// All addresses apply to the container interface
-			ipc.Interface = current.Int(0)
-		}
-
-		// wait until OF port link state becomes up. This is needed to make
-		// gratuitous arp for args.IfName to be sent over ovs bridge
-		err = waitLinkUp(ovsBridgeDriver, hostIface.Name, netconf.LinkStateCheckRetries, netconf.LinkStateCheckInterval)
-		if err != nil {
-			return err
-		}
-
-		err = contNetns.Do(func(_ ns.NetNS) error {
-			if mac == "" && !sriov.IsOvsHardwareOffloadEnabled(netconf.DeviceID) && len(newResult.IPs) >= 1 {
-				containerMac := common.IPAddrToHWAddr(newResult.IPs[0].Address.IP)
-				containerLink, err := netlink.LinkByName(args.IfName)
-				if err != nil {
-					return fmt.Errorf("failed to lookup container interface %q: %v", args.IfName, err)
-				}
-				err = assignMacToLink(containerLink, containerMac, args.IfName)
-				if err != nil {
-					return err
-				}
-				newResult.Interfaces[0].Mac = containerMac.String()
-			}
-			err := ipam.ConfigureIface(args.IfName, newResult)
-			if err != nil {
-				return err
-			}
-			contVeth, err := net.InterfaceByName(args.IfName)
-			if err != nil {
-				return fmt.Errorf("failed to look up %q: %v", args.IfName, err)
-			}
-			for _, ipc := range newResult.IPs {
-				// if ip address version is 4
-				if ipc.Address.IP.To4() != nil {
-					// send gratuitous arp for other ends to refresh its arp cache
-					err = arping.GratuitousArpOverIface(ipc.Address.IP, *contVeth)
-					if err != nil {
-						// ok to ignore returning this error
-						log.Printf("error sending garp for ip %s: %v", ipc.Address.IP.String(), err)
-					}
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-		result = newResult
-		result.Interfaces = []*current.Interface{hostIface, result.Interfaces[0]}
-
-		for ifIndex, ifCfg := range result.Interfaces {
-			// Adjust interface index with new container interface index in result.Interfaces
-			if ifCfg.Name == args.IfName {
-				for ipIndex := range result.IPs {
-					result.IPs[ipIndex].Interface = current.Int(ifIndex)
-				}
-			}
 		}
 	}
 
 	return cnitypes.PrintResult(result, netconf.CNIVersion)
-}
-
-func waitLinkUp(ovsDriver *ovsdb.OvsBridgeDriver, ofPortName string, retryCount, interval int) error {
-	checkInterval := time.Duration(interval) * time.Millisecond
-	for i := 1; i <= retryCount; i++ {
-		portState, err := ovsDriver.GetOFPortOpState(ofPortName)
-		if err != nil {
-			log.Printf("error in retrieving port %s state: %v", ofPortName, err)
-		} else {
-			if portState == "up" {
-				break
-			}
-		}
-		if i == retryCount {
-			return fmt.Errorf("The OF port %s state is not up, try increasing number of retries/interval config parameter", ofPortName)
-		}
-		time.Sleep(checkInterval)
-	}
-	return nil
 }
 
 // CmdDel remove handler for deleting container from network

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -52,14 +52,6 @@ const (
 	portTypeTrunk  = "trunk"
 )
 
-// EnvArgs args containing common, desired mac and ovs port name
-type EnvArgs struct {
-	cnitypes.CommonArgs
-	MAC         cnitypes.UnmarshallableString `json:"mac,omitempty"`
-	OvnPort     cnitypes.UnmarshallableString `json:"ovnPort,omitempty"`
-	K8S_POD_UID cnitypes.UnmarshallableString
-}
-
 func init() {
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
@@ -72,9 +64,9 @@ func logCall(command string, args *skel.CmdArgs) {
 		command, args.ContainerID, args.Netns, args.IfName, string(args.StdinData[:]))
 }
 
-func getEnvArgs(envArgsString string) (*EnvArgs, error) {
+func getEnvArgs(envArgsString string) (*types.EnvArgs, error) {
 	if envArgsString != "" {
-		e := EnvArgs{}
+		e := types.EnvArgs{}
 		err := cnitypes.LoadArgs(envArgsString, &e)
 		if err != nil {
 			return nil, err

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -47,11 +47,6 @@ import (
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
 )
 
-const (
-	portTypeAccess = "access"
-	portTypeTrunk  = "trunk"
-)
-
 func init() {
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
@@ -224,21 +219,11 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	var vlanTagNum uint = 0
-	trunks := make([]uint, 0)
-	portType := portTypeAccess
-	if netconf.VlanTag == nil || len(netconf.Trunk) > 0 {
-		portType = portTypeTrunk
-		if len(netconf.Trunk) > 0 {
-			trunkVlanIds, err := common.SplitVlanIds(netconf.Trunk)
-			if err != nil {
-				return err
-			}
-			trunks = append(trunks, trunkVlanIds...)
-		}
-	} else if netconf.VlanTag != nil {
-		vlanTagNum = *netconf.VlanTag
+	portCfg, err := common.ParseOvsPortConfig(netconf)
+	if err != nil {
+		return err
 	}
+
 	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
 	if err != nil {
 		return err
@@ -306,7 +291,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	if err = attachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, vlanTagNum, trunks, portType, netconf.InterfaceType, args.Netns, ovnPort, contPodUid); err != nil {
+	if err = attachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, portCfg.VlanTag, portCfg.Trunks, portCfg.Type, netconf.InterfaceType, args.Netns, ovnPort, contPodUid); err != nil {
 		return err
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -227,7 +227,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// removes all ports whose interfaces have an error
-	if err := cleanPorts(ovsBridgeDriver); err != nil {
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
 		return err
 	}
 
@@ -415,23 +415,6 @@ func getOvsPortForContIface(ovsDriver *ovsdb.OvsBridgeDriver, contIface string, 
 	return ovsDriver.GetOvsPortForContIface(contIface, contNetnsPath)
 }
 
-// cleanPorts removes all ports whose interfaces have an error.
-func cleanPorts(ovsDriver *ovsdb.OvsBridgeDriver) error {
-	ifaces, err := ovsDriver.FindInterfacesWithError()
-	if err != nil {
-		return fmt.Errorf("clean ports: %v", err)
-	}
-	for _, iface := range ifaces {
-		log.Printf("Info: interface %s has error: removing corresponding port", iface)
-		if err := ovsDriver.DeletePort(iface); err != nil {
-			// Don't return an error here, just log its occurrence.
-			// Something else may have removed the port already.
-			log.Printf("Error: %v\n", err)
-		}
-	}
-	return nil
-}
-
 func removeOvsPort(ovsDriver *ovsdb.OvsBridgeDriver, portName string) error {
 	return ovsDriver.DeletePort(portName)
 }
@@ -514,7 +497,7 @@ func CmdDel(args *skel.CmdArgs) error {
 			}
 		} else {
 			// In accordance with the spec we clean up as many resources as possible.
-			if err := cleanPorts(ovsBridgeDriver); err != nil {
+			if err := common.CleanPorts(ovsBridgeDriver); err != nil {
 				return err
 			}
 		}
@@ -566,7 +549,7 @@ func CmdDel(args *skel.CmdArgs) error {
 	}
 
 	// removes all ports whose interfaces have an error
-	if err := cleanPorts(ovsBridgeDriver); err != nil {
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
 		return err
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -115,7 +115,7 @@ func setupVeth(contNetns ns.NetNS, contIfaceName string, requestedMac string, mt
 	}
 
 	// Refetch the hostIface since its MAC address may change during network namespace move.
-	if err = refetchIface(hostIface); err != nil {
+	if err = common.RefetchIface(hostIface); err != nil {
 		return nil, nil, err
 	}
 
@@ -158,15 +158,6 @@ func attachIfaceToBridge(ovsDriver *ovsdb.OvsBridgeDriver, hostIfaceName string,
 		return err
 	}
 
-	return nil
-}
-
-func refetchIface(iface *current.Interface) error {
-	link, err := netlink.LinkByName(iface.Name)
-	if err != nil {
-		return fmt.Errorf("failed to refetch interface %s: %v", iface.Name, err)
-	}
-	iface.Mac = link.Attrs().HardwareAddr.String()
 	return nil
 }
 
@@ -271,7 +262,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	// Refetch the host interface MAC since OVS may change it when
 	// attaching the port to the bridge.
-	if err = refetchIface(hostIface); err != nil {
+	if err = common.RefetchIface(hostIface); err != nil {
 		return err
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -355,7 +355,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := validateCache(cache, netconf); err != nil {
+	if err := common.ValidateCache(cache, netconf); err != nil {
 		return err
 	}
 
@@ -439,30 +439,6 @@ func CmdCheck(args *skel.CmdArgs) error {
 	// ovs specific check
 	if err := common.ValidateOvs(args, netconf, hostIntf.Name); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func validateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
-	if cache.Netconf.BrName != netconf.BrName {
-		return fmt.Errorf("BrName mismatch. cache=%s,netconf=%s",
-			cache.Netconf.BrName, netconf.BrName)
-	}
-
-	if cache.Netconf.SocketFile != netconf.SocketFile {
-		return fmt.Errorf("SocketFile mismatch. cache=%s,netconf=%s",
-			cache.Netconf.SocketFile, netconf.SocketFile)
-	}
-
-	if cache.Netconf.IPAM.Type != netconf.IPAM.Type {
-		return fmt.Errorf("IPAM mismatch. cache=%s,netconf=%s",
-			cache.Netconf.IPAM.Type, netconf.IPAM.Type)
-	}
-
-	if cache.Netconf.DeviceID != netconf.DeviceID {
-		return fmt.Errorf("DeviceID mismatch. cache=%s,netconf=%s",
-			cache.Netconf.DeviceID, netconf.DeviceID)
 	}
 
 	return nil

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -369,14 +368,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Parse previous result.
-	if netconf.NetConf.RawPrevResult == nil {
-		return fmt.Errorf("Required prevResult missing")
-	}
-	if err := version.ParsePrevResult(&netconf.NetConf); err != nil {
-		return err
-	}
-	result, err := current.NewResultFromResult(netconf.NetConf.PrevResult)
+	result, err := common.ParsePrevResult(netconf)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -373,26 +373,9 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
-	var contIntf, hostIntf current.Interface
-	// Find interfaces
-	for _, intf := range result.Interfaces {
-		if args.IfName == intf.Name {
-			if args.Netns == intf.Sandbox {
-				contIntf = *intf
-			}
-		} else {
-			// Check prevResults for ips against values found in the host
-			if err := common.ValidateInterface(*intf, true, ovsHWOffloadEnable); err != nil {
-				return err
-			}
-			hostIntf = *intf
-		}
-	}
-
-	// The namespace must be the same as what was configured
-	if args.Netns != contIntf.Sandbox {
-		return fmt.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
-			contIntf.Sandbox, args.Netns)
+	hostIntf, contIntf, err := common.ExtractInterfaces(args, result, ovsHWOffloadEnable)
+	if err != nil {
+		return err
 	}
 
 	netns, err := ns.GetNS(args.Netns)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -325,7 +325,6 @@ func CmdCheck(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-	ovsHWOffloadEnable := common.IsOvsHardwareOffloadEnabled(netconf.DeviceID)
 
 	envArgs, err := common.GetEnvArgs(args.Args)
 	if err != nil {
@@ -368,26 +367,5 @@ func CmdCheck(args *skel.CmdArgs) error {
 		}
 	}
 
-	result, err := common.ParsePrevResult(netconf)
-	if err != nil {
-		return err
-	}
-
-	hostIntf, contIntf, err := common.ExtractInterfaces(args, result, ovsHWOffloadEnable)
-	if err != nil {
-		return err
-	}
-
-	// Check prevResults for ips and routes against values found in the container
-	err = common.ValidateNetnsAttachment(args, result, contIntf, ovsHWOffloadEnable)
-	if err != nil {
-		return nil
-	}
-
-	// ovs specific check
-	if err := common.ValidateOvs(args, netconf, hostIntf.Name); err != nil {
-		return err
-	}
-
-	return nil
+	return common.ValidateAttachment(args, netconf, cache)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
@@ -211,92 +210,12 @@ func CmdDel(args *skel.CmdArgs) error {
 		}
 	}()
 
-	envArgs, err := common.GetEnvArgs(args.Args)
-	if err != nil {
-		return err
-	}
-
 	if !common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
 		err = veth.CmdDel(args, cache)
 		return err
 	}
 
-	var ovnPort string
-	if envArgs != nil {
-		ovnPort = string(envArgs.OvnPort)
-	}
-	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
-	if err != nil {
-		return err
-	}
-	bridgeName, err := sriov.GetBridgeName(ovsDriver, cache.Netconf.BrName, ovnPort, cache.Netconf.DeviceID)
-	if err != nil {
-		return err
-	}
-
-	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, cache.Netconf.SocketFile)
-	if err != nil {
-		return err
-	}
-
-	if cache.Netconf.IPAM.Type != "" {
-		err = ipam.ExecDel(cache.Netconf.IPAM.Type, args.StdinData)
-		if err != nil {
-			return err
-		}
-	}
-
-	if args.Netns == "" {
-		// The CNI_NETNS parameter may be empty according to version 0.4.0
-		// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
-		if common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
-			// SR-IOV Case - The sriov device is moved into host network namespace when args.Netns is empty.
-			// This happens container is killed due to an error (example: CrashLoopBackOff, OOMKilled)
-			var rep string
-			if rep, err = sriov.GetNetRepresentor(cache.Netconf.DeviceID); err != nil {
-				return err
-			}
-			if err = common.RemoveOvsPort(ovsBridgeDriver, rep); err != nil {
-				// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
-				// port is already deleted in a previous invocation.
-				log.Printf("Error: %v\n", err)
-			}
-			// there is no network interface in case of userspace driver, so OrigIfName is empty
-			if !cache.UserspaceMode {
-				if err = sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	}
-
-	// Unlike veth pair, OVS port will not be automatically removed when
-	// container namespace is gone. Find port matching DEL arguments and remove
-	// it explicitly.
-	_, _, err = common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
-	if err != nil {
-		return err
-	}
-
-	if common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
-		// there is no network interface in case of userspace driver, so OrigIfName is empty
-		if !cache.UserspaceMode {
-			err = sriov.ReleaseVF(args, cache.OrigIfName)
-			if err != nil {
-				// try to reset vf into original state as much as possible in case of error
-				if err := sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
-					log.Printf("Failed best-effort cleanup of VF %s: %v", cache.OrigIfName, err)
-				}
-			}
-		}
-	}
-
-	// removes all ports whose interfaces have an error
-	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
-		return err
-	}
-
+	err = sriov.CmdDel(args, cache)
 	return err
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -21,20 +21,14 @@
 package plugin
 
 import (
-	"fmt"
 	"log"
 	"runtime"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	cnitypes "github.com/containernetworking/cni/pkg/types"
-	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
-	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
-	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/veth"
 )
@@ -55,20 +49,6 @@ func logCall(command string, args *skel.CmdArgs) {
 func CmdAdd(args *skel.CmdArgs) error {
 	logCall("ADD", args)
 
-	envArgs, err := common.GetEnvArgs(args.Args)
-	if err != nil {
-		return err
-	}
-
-	var mac string
-	var ovnPort string
-	var contPodUid string
-	if envArgs != nil {
-		mac = string(envArgs.MAC)
-		ovnPort = string(envArgs.OvnPort)
-		contPodUid = string(envArgs.K8S_POD_UID)
-	}
-
 	netconf, err := config.LoadConf(args.StdinData)
 	if err != nil {
 		return err
@@ -78,111 +58,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return veth.CmdAdd(args, netconf)
 	}
 
-	portCfg, err := common.ParseOvsPortConfig(netconf)
-	if err != nil {
-		return err
-	}
-
-	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
-	if err != nil {
-		return err
-	}
-	bridgeName, err := sriov.GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
-	if err != nil {
-		return err
-	}
-	// save discovered bridge name to the netconf struct to make
-	// sure it is save in the cache.
-	// we need to cache discovered bridge name to make sure that we will
-	// use the right bridge name in CmdDel
-	netconf.BrName = bridgeName
-
-	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, netconf.SocketFile)
-	if err != nil {
-		return err
-	}
-
-	// check if the device driver is the type of userspace driver
-	userspaceMode := false
-	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
-		userspaceMode, err = sriov.HasUserspaceDriver(netconf.DeviceID)
-		if err != nil {
-			return err
-		}
-	}
-
-	// removes all ports whose interfaces have an error
-	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
-		return err
-	}
-
-	contNetns, err := ns.GetNS(args.Netns)
-	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
-	}
-	defer func() { _ = contNetns.Close() }()
-
-	// userspace driver does not create a network interface for the VF on the host
-	var origIfName string
-	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) && !userspaceMode {
-		origIfName, err = sriov.GetVFLinkName(netconf.DeviceID)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Cache NetConf for CmdDel
-	if err = utils.SaveCache(config.GetCRef(args.ContainerID, args.IfName),
-		&types.CachedNetConf{Netconf: netconf, OrigIfName: origIfName, UserspaceMode: userspaceMode}); err != nil {
-		return fmt.Errorf("error saving NetConf %q", err)
-	}
-
-	var hostIface, contIface *current.Interface
-	if common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
-		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, mac, netconf.MTU, netconf.DeviceID, userspaceMode)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err = common.AttachIfaceToBridge(ovsBridgeDriver, hostIface.Name, contIface.Name, netconf.OfportRequest, portCfg.VlanTag, portCfg.Trunks, portCfg.Type, netconf.InterfaceType, args.Netns, ovnPort, contPodUid); err != nil {
-		return err
-	}
-
-	// Refetch the host interface MAC since OVS may change it when
-	// attaching the port to the bridge.
-	if err = common.RefetchIface(hostIface); err != nil {
-		return err
-	}
-
-	defer func() {
-		if err != nil {
-			// Unlike veth pair, OVS port will not be automatically removed
-			// if the following IPAM configuration fails and netns gets removed.
-			_, _, err = common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
-			if err != nil {
-				log.Printf("Failed best-effort cleanup: %v", err)
-			}
-		}
-	}()
-
-	result := &current.Result{
-		Interfaces: []*current.Interface{hostIface, contIface},
-	}
-
-	// run the IPAM plugin
-	// userspace driver does not support IPAM plugin,
-	// because there is no network interface for the VF on the host
-	if netconf.IPAM.Type != "" && !userspaceMode {
-		result, err = common.ManagedIPAMAddCall(
-			ovsBridgeDriver, args, netconf, mac, hostIface, contIface, contNetns, common.IsOvsHardwareOffloadEnabled(netconf.DeviceID),
-		)
-		if err != nil {
-			return err
-		}
-	}
-
-	return cnitypes.PrintResult(result, netconf.CNIVersion)
+	return sriov.CmdAdd(args, netconf)
 }
 
 // CmdDel remove handler for deleting container from network

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,8 +28,10 @@ import (
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/deviceinfo"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/vdpa"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/veth"
 )
 
@@ -52,6 +54,15 @@ func CmdAdd(args *skel.CmdArgs) error {
 	netconf, err := config.LoadConf(args.StdinData)
 	if err != nil {
 		return err
+	}
+
+	deviceInfo, err := deviceinfo.GetDeviceInfo(netconf)
+	if err != nil {
+		return err
+	}
+
+	if vdpa.IsVdpa(deviceInfo) {
+		return vdpa.CmdAdd(args, netconf)
 	}
 
 	if !common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {
@@ -86,6 +97,11 @@ func CmdDel(args *skel.CmdArgs) error {
 		}
 	}()
 
+	if vdpa.CachedDeviceIsVdpa(cache) {
+		err = vdpa.CmdDel(args, cache)
+		return err
+	}
+
 	if !common.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
 		err = veth.CmdDel(args, cache)
 		return err
@@ -102,6 +118,15 @@ func CmdCheck(args *skel.CmdArgs) error {
 	netconf, err := config.LoadConf(args.StdinData)
 	if err != nil {
 		return err
+	}
+
+	deviceInfo, err := deviceinfo.GetDeviceInfo(netconf)
+	if err != nil {
+		return err
+	}
+
+	if vdpa.IsVdpa(deviceInfo) {
+		return vdpa.CmdCheck(args, netconf)
 	}
 
 	if !common.IsOvsHardwareOffloadEnabled(netconf.DeviceID) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -32,7 +32,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
@@ -408,7 +407,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 			}
 		} else {
 			// Check prevResults for ips against values found in the host
-			if err := validateInterface(*intf, true, ovsHWOffloadEnable); err != nil {
+			if err := common.ValidateInterface(*intf, true, ovsHWOffloadEnable); err != nil {
 				return err
 			}
 			hostIntf = *intf
@@ -430,7 +429,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 	// Check prevResults for ips and routes against values found in the container
 	if err := netns.Do(func(_ ns.NetNS) error {
 		// Check interface against values found in the container
-		err := validateInterface(contIntf, false, ovsHWOffloadEnable)
+		err := common.ValidateInterface(contIntf, false, ovsHWOffloadEnable)
 		if err != nil {
 			return err
 		}
@@ -476,40 +475,6 @@ func validateCache(cache *types.CachedNetConf, netconf *types.NetConf) error {
 	if cache.Netconf.DeviceID != netconf.DeviceID {
 		return fmt.Errorf("DeviceID mismatch. cache=%s,netconf=%s",
 			cache.Netconf.DeviceID, netconf.DeviceID)
-	}
-
-	return nil
-}
-
-func validateInterface(intf current.Interface, isHost bool, hwOffload bool) error {
-	var link netlink.Link
-	var err error
-	var iftype string
-	if isHost {
-		iftype = "Host"
-	} else {
-		iftype = "Container"
-	}
-
-	if intf.Name == "" {
-		return fmt.Errorf("%s interface name missing in prevResult: %v", iftype, intf.Name)
-	}
-	link, err = netlink.LinkByName(intf.Name)
-	if err != nil {
-		return fmt.Errorf("Error: %s Interface name in prevResult: %s not found", iftype, intf.Name)
-	}
-	if !isHost && intf.Sandbox == "" {
-		return fmt.Errorf("Error: %s interface %s should not be in host namespace", iftype, link.Attrs().Name)
-	}
-	if !hwOffload {
-		_, isVeth := link.(*netlink.Veth)
-		if !isVeth {
-			return fmt.Errorf("Error: %s interface %s not of type veth/p2p", iftype, link.Attrs().Name)
-		}
-	}
-
-	if intf.Mac != "" && intf.Mac != link.Attrs().HardwareAddr.String() {
-		return fmt.Errorf("Error: Interface %s Mac %s doesn't match %s Mac: %s", intf.Name, intf.Mac, iftype, link.Attrs().HardwareAddr)
 	}
 
 	return nil

--- a/pkg/sriov/plugin.go
+++ b/pkg/sriov/plugin.go
@@ -14,6 +14,7 @@ package sriov
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/plugins/pkg/ipam"
@@ -22,6 +23,87 @@ import (
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
+
+func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+
+	var ovnPort string
+	if envArgs != nil {
+		ovnPort = string(envArgs.OvnPort)
+	}
+	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+	bridgeName, err := GetBridgeName(ovsDriver, cache.Netconf.BrName, ovnPort, cache.Netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, cache.Netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	if cache.Netconf.IPAM.Type != "" {
+		err = ipam.ExecDel(cache.Netconf.IPAM.Type, args.StdinData)
+		if err != nil {
+			return err
+		}
+	}
+
+	// The CNI_NETNS parameter may be empty according to version 0.4.0
+	// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
+	if args.Netns == "" {
+		// SR-IOV Case - The sriov device is moved into host network namespace when args.Netns is empty.
+		// This happens container is killed due to an error (example: CrashLoopBackOff, OOMKilled)
+		var rep string
+		if rep, err = GetNetRepresentor(cache.Netconf.DeviceID); err != nil {
+			return err
+		}
+		if err = common.RemoveOvsPort(ovsBridgeDriver, rep); err != nil {
+			// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
+			// port is already deleted in a previous invocation.
+			log.Printf("Error: %v\n", err)
+		}
+		// there is no network interface in case of userspace driver, so OrigIfName is empty
+		if !cache.UserspaceMode {
+			if err = ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Unlike veth pair, OVS port will not be automatically removed when
+	// container namespace is gone. Find port matching DEL arguments and remove
+	// it explicitly.
+	_, _, err = common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+	if err != nil {
+		return err
+	}
+
+	// there is no network interface in case of userspace driver, so OrigIfName is empty
+	if !cache.UserspaceMode {
+		err = ReleaseVF(args, cache.OrigIfName)
+		if err != nil {
+			// try to reset vf into original state as much as possible in case of error
+			if err := ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
+				log.Printf("Failed best-effort cleanup of VF %s: %v", cache.OrigIfName, err)
+			}
+		}
+	}
+
+	// removes all ports whose interfaces have an error
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
+		return err
+	}
+
+	return err
+}
 
 func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
 	envArgs, err := common.GetEnvArgs(args.Args)

--- a/pkg/sriov/plugin.go
+++ b/pkg/sriov/plugin.go
@@ -17,12 +17,144 @@ import (
 	"log"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ipam"
+	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
 )
+
+func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+
+	var mac string
+	var ovnPort string
+	var contPodUid string
+	if envArgs != nil {
+		mac = string(envArgs.MAC)
+		ovnPort = string(envArgs.OvnPort)
+		contPodUid = string(envArgs.K8S_POD_UID)
+	}
+
+	portCfg, err := common.ParseOvsPortConfig(netconf)
+	if err != nil {
+		return err
+	}
+
+	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+	bridgeName, err := GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+	// save discovered bridge name to the netconf struct to make
+	// sure it is save in the cache.
+	// we need to cache discovered bridge name to make sure that we will
+	// use the right bridge name in CmdDel
+	netconf.BrName = bridgeName
+
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	// check if the device driver is the type of userspace driver
+	userspaceMode, err := HasUserspaceDriver(netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+
+	// removes all ports whose interfaces have an error
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
+		return err
+	}
+
+	contNetns, err := ns.GetNS(args.Netns)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	}
+	defer func() { _ = contNetns.Close() }()
+
+	// userspace driver does not create a network interface for the VF on the host
+	var origIfName string
+	if !userspaceMode {
+		origIfName, err = GetVFLinkName(netconf.DeviceID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Cache NetConf for CmdDel
+	if err = utils.SaveCache(config.GetCRef(args.ContainerID, args.IfName),
+		&types.CachedNetConf{Netconf: netconf, OrigIfName: origIfName, UserspaceMode: userspaceMode}); err != nil {
+		return fmt.Errorf("error saving NetConf %q", err)
+	}
+
+	hostIface, contIface, err := SetupSriovInterface(contNetns, args.ContainerID, args.IfName, mac, netconf.MTU, netconf.DeviceID, userspaceMode)
+	if err != nil {
+		return err
+	}
+
+	if err = common.AttachIfaceToBridge(ovsBridgeDriver,
+		hostIface.Name,
+		contIface.Name,
+		netconf.OfportRequest,
+		portCfg.VlanTag,
+		portCfg.Trunks,
+		portCfg.Type,
+		netconf.InterfaceType,
+		args.Netns,
+		ovnPort,
+		contPodUid,
+	); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			// Unlike veth pair, OVS port will not be automatically removed
+			// if the following IPAM configuration fails and netns gets removed.
+			_, _, cleanupErr := common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+			if cleanupErr != nil {
+				log.Printf("Failed best-effort cleanup: %v", cleanupErr)
+			}
+		}
+	}()
+
+	// Refetch the host interface MAC since OVS may change it when
+	// attaching the port to the bridge.
+	if err = common.RefetchIface(hostIface); err != nil {
+		return err
+	}
+
+	result := &current.Result{
+		Interfaces: []*current.Interface{hostIface, contIface},
+	}
+
+	// run the IPAM plugin
+	// userspace driver does not support IPAM plugin,
+	// because there is no network interface for the VF on the host
+	if netconf.IPAM.Type != "" && !userspaceMode {
+		result, err = common.ManagedIPAMAddCall(
+			ovsBridgeDriver, args, netconf, mac, hostIface, contIface, contNetns, true,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cnitypes.PrintResult(result, netconf.CNIVersion)
+}
 
 func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
 	envArgs, err := common.GetEnvArgs(args.Args)

--- a/pkg/sriov/plugin.go
+++ b/pkg/sriov/plugin.go
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sriov
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/plugins/pkg/ipam"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+)
+
+func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+	var ovnPort string
+	if envArgs != nil {
+		ovnPort = string(envArgs.OvnPort)
+	}
+
+	// Discover bridge name using SR-IOV specific logic
+	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+	bridgeName, err := GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+	netconf.BrName = bridgeName
+
+	// check cache
+	cache, err := common.CacheLoadAndCheck(args, netconf)
+	if err != nil {
+		return err
+	}
+
+	// TODO: CmdCheck for userspace driver
+	if cache.UserspaceMode {
+		return nil
+	}
+
+	// run the IPAM plugin
+	if netconf.NetConf.IPAM.Type != "" {
+		if err := ipam.ExecCheck(netconf.NetConf.IPAM.Type, args.StdinData); err != nil {
+			return fmt.Errorf("failed to check with IPAM plugin type %q: %v", netconf.NetConf.IPAM.Type, err)
+		}
+	}
+
+	return common.ValidateAttachment(args, netconf, cache)
+}

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -208,7 +208,7 @@ func setupKernelSriovContIface(contNetns ns.NetNS, contIface *current.Interface,
 	}
 
 	// Move smart VF to Container namespace
-	err = moveIfToNetns(vfNetdevice, contNetns)
+	err = MoveVFToNetns(vfNetdevice, contNetns)
 	if err != nil {
 		return err
 	}
@@ -342,7 +342,7 @@ func SetupSriovInterface(contNetns ns.NetNS, containerID, ifName, mac string, mt
 	return hostIface, contIface, nil
 }
 
-func moveIfToNetns(ifname string, netns ns.NetNS) error {
+func MoveVFToNetns(ifname string, netns ns.NetNS) error {
 	vfDev, err := netlink.LinkByName(ifname)
 	if err != nil {
 		return fmt.Errorf("failed to lookup vf device %v: %q", ifname, err)

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -215,7 +215,7 @@ func setupKernelSriovContIface(contNetns ns.NetNS, contIface *current.Interface,
 
 	err = contNetns.Do(func(hostNS ns.NetNS) error {
 		contIface.Name = ifName
-		_, err = renameLink(vfNetdevice, contIface.Name)
+		_, err = RenameLink(vfNetdevice, contIface.Name)
 		if err != nil {
 			return err
 		}
@@ -356,7 +356,7 @@ func MoveVFToNetns(ifname string, netns ns.NetNS) error {
 	return nil
 }
 
-func renameLink(curName, newName string) (netlink.Link, error) {
+func RenameLink(curName, newName string) (netlink.Link, error) {
 	link, err := netlink.LinkByName(curName)
 	if err != nil {
 		return nil, err
@@ -388,7 +388,7 @@ func ReleaseVF(args *skel.CmdArgs, origIfName string) error {
 
 	return contNetns.Do(func(_ ns.NetNS) error {
 		// rename VF device back to its original name
-		linkObj, err := renameLink(args.IfName, origIfName)
+		linkObj, err := RenameLink(args.IfName, origIfName)
 		if err != nil {
 			return err
 		}
@@ -414,7 +414,7 @@ func ResetVF(args *skel.CmdArgs, deviceID, origIfName string) error {
 		// until link is available.
 		return ip.ErrLinkNotFound
 	}
-	_, err = renameLink(vfNetdevices[0], origIfName)
+	_, err = RenameLink(vfNetdevices[0], origIfName)
 	if err != nil {
 		return err
 	}

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -60,12 +60,6 @@ func GetVFLinkName(pciAddr string) (string, error) {
 	return names[0], nil
 }
 
-// IsOvsHardwareOffloadEnabled when device id is set, then ovs hardware offload
-// is enabled.
-func IsOvsHardwareOffloadEnabled(deviceID string) bool {
-	return deviceID != ""
-}
-
 // HasUserspaceDriver checks if a device is attached to userspace driver
 // This method is copied from https://github.com/k8snetworkplumbingwg/sriov-cni/blob/8af83a33b2cac8e2df0bd6276b76658eb7c790ab/pkg/utils/utils.go#L222
 func HasUserspaceDriver(pciAddr string) (bool, error) {

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -24,6 +24,9 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/vishvananda/netlink"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
 )
 
 var (
@@ -420,4 +423,31 @@ func ResetVF(args *skel.CmdArgs, deviceID, origIfName string) error {
 	}
 
 	return nil
+}
+
+func GetBridgeName(driver *ovsdb.OvsDriver, bridgeName, ovnPort, deviceID string) (string, error) {
+	ret, err := common.GetBridgeName(bridgeName, ovnPort)
+	if err == nil {
+		return ret, nil
+	}
+
+	if deviceID != "" {
+		possibleUplinkNames, err := GetBridgeUplinkNameByDeviceID(deviceID)
+		if err != nil {
+			return "", fmt.Errorf("failed to get bridge name - failed to resolve uplink name: %v", err)
+		}
+		var errList []error
+		for _, uplinkName := range possibleUplinkNames {
+			bridgeName, err = driver.FindBridgeByInterface(uplinkName)
+			if err != nil {
+				errList = append(errList,
+					fmt.Errorf("failed to get bridge name - failed to find bridge name by uplink name %s: %v", uplinkName, err))
+				continue
+			}
+			return bridgeName, nil
+		}
+		return "", fmt.Errorf("failed to find bridge by uplink names %v: %v", possibleUplinkNames, errList)
+	}
+
+	return "", err
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -98,15 +98,26 @@ type Trunk struct {
 	ID    *uint `json:"id,omitempty"`
 }
 
+// VdpaDeviceType contains the type of vdpa device that an interface is
+// running on, if any.
+type VdpaDeviceType string
+
+const (
+	VdpaDeviceTypeNone        = ""
+	VdpaDeviceTypeKernelVhost = "VdpaKernelVhost"
+)
+
 // CachedNetConf containing NetConfig, original smartnic vf interface name
-// and kernel/userspace device driver mode of the smartnic vf interface
-// (the last two are set only in case of ovs hareware offload scenario).
+// kernel/userspace device driver mode of the smartnic vf interface and
+// the vdpa device type (the last three are set only in case of ovs
+// hardware offload scenario).
 // this is intended to be used only for storing and retrieving config
 // to/from a data store (example file cache).
 type CachedNetConf struct {
 	Netconf       *NetConf
 	OrigIfName    string
 	UserspaceMode bool
+	VdpaType      VdpaDeviceType
 }
 
 // CachedPrevResultNetConf containing PrevResult.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -28,20 +28,26 @@ type NetConfs interface {
 	NetConf | MirrorNetConf
 }
 
+type RuntimeConfig struct {
+	types.CommonArgs
+	CNIDeviceInfoFile string `json:"CNIDeviceInfoFile,omitempty"`
+}
+
 // NetConf extends types.NetConf for ovs-cni
 type NetConf struct {
 	types.NetConf
-	BrName                 string   `json:"bridge,omitempty"`
-	VlanTag                *uint    `json:"vlan"`
-	MTU                    int      `json:"mtu"`
-	Trunk                  []*Trunk `json:"trunk,omitempty"`
-	DeviceID               string   `json:"deviceID"`       // PCI address of a VF in valid sysfs format
-	OfportRequest          uint     `json:"ofport_request"` // OpenFlow port number in range 1 to 65,279
-	InterfaceType          string   `json:"interface_type"` // The type of interface on ovs.
-	ConfigurationPath      string   `json:"configuration_path"`
-	SocketFile             string   `json:"socket_file"`
-	LinkStateCheckRetries  int      `json:"link_state_check_retries"`
-	LinkStateCheckInterval int      `json:"link_state_check_interval"`
+	BrName                 string         `json:"bridge,omitempty"`
+	VlanTag                *uint          `json:"vlan"`
+	MTU                    int            `json:"mtu"`
+	Trunk                  []*Trunk       `json:"trunk,omitempty"`
+	DeviceID               string         `json:"deviceID"`       // PCI address of a VF in valid sysfs format
+	OfportRequest          uint           `json:"ofport_request"` // OpenFlow port number in range 1 to 65,279
+	InterfaceType          string         `json:"interface_type"` // The type of interface on ovs.
+	ConfigurationPath      string         `json:"configuration_path"`
+	SocketFile             string         `json:"socket_file"`
+	LinkStateCheckRetries  int            `json:"link_state_check_retries"`
+	LinkStateCheckInterval int            `json:"link_state_check_interval"`
+	RuntimeConfig          *RuntimeConfig `json:"runtimeConfig,omitempty"`
 }
 
 // netConfAlias is used to avoid infinite recursion when marshaling NetConf.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -117,3 +117,11 @@ type CachedNetConf struct {
 type CachedPrevResultNetConf struct {
 	PrevResult *current.Result
 }
+
+// EnvArgs args containing common, desired mac and ovs port name
+type EnvArgs struct {
+	types.CommonArgs
+	MAC         types.UnmarshallableString `json:"mac,omitempty"`
+	OvnPort     types.UnmarshallableString `json:"ovnPort,omitempty"`
+	K8S_POD_UID types.UnmarshallableString
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -104,15 +104,26 @@ type Trunk struct {
 	ID    *uint `json:"id,omitempty"`
 }
 
+// VdpaDeviceType contains the type of vdpa device that an interface is
+// running on, if any.
+type VdpaDeviceType string
+
+const (
+	VdpaDeviceTypeNone        = ""
+	VdpaDeviceTypeKernelVhost = "VdpaKernelVhost"
+)
+
 // CachedNetConf containing NetConfig, original smartnic vf interface name
-// and kernel/userspace device driver mode of the smartnic vf interface
-// (the last two are set only in case of ovs hareware offload scenario).
+// kernel/userspace device driver mode of the smartnic vf interface and
+// the vdpa device type (the last three are set only in case of ovs
+// hardware offload scenario).
 // this is intended to be used only for storing and retrieving config
 // to/from a data store (example file cache).
 type CachedNetConf struct {
 	Netconf       *NetConf
 	OrigIfName    string
 	UserspaceMode bool
+	VdpaType      VdpaDeviceType
 }
 
 // CachedPrevResultNetConf containing PrevResult.

--- a/pkg/vdpa/plugin.go
+++ b/pkg/vdpa/plugin.go
@@ -1,0 +1,225 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdpa
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
+)
+
+func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+
+	var mac string
+	var ovnPort string
+	var contPodUid string
+	if envArgs != nil {
+		mac = string(envArgs.MAC)
+		ovnPort = string(envArgs.OvnPort)
+		contPodUid = string(envArgs.K8S_POD_UID)
+	}
+
+	portCfg, err := common.ParseOvsPortConfig(netconf)
+	if err != nil {
+		return err
+	}
+
+	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+	bridgeName, err := sriov.GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+	// save discovered bridge name to the netconf struct to make
+	// sure it is save in the cache.
+	// we need to cache discovered bridge name to make sure that we will
+	// use the right bridge name in CmdDel
+	netconf.BrName = bridgeName
+
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	// removes all ports whose interfaces have an error
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
+		return err
+	}
+
+	contNetns, err := ns.GetNS(args.Netns)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	}
+	defer func() { _ = contNetns.Close() }()
+
+	vdpaDev, err := getVdpaDeviceFromID(netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+	vdpaDevType, err := getDeviceType(vdpaDev)
+	if err != nil {
+		return err
+	}
+
+	// Cache NetConf for CmdDel
+	if err = utils.SaveCache(config.GetCRef(args.ContainerID, args.IfName),
+		&types.CachedNetConf{Netconf: netconf, UserspaceMode: false, VdpaType: vdpaDevType}); err != nil {
+		return fmt.Errorf("error saving NetConf %q", err)
+	}
+
+	hostIface, contIface, err := setupVdpaInterface(contNetns, args.IfName, netconf.DeviceID, mac, vdpaDev, netconf.MTU)
+	if err != nil {
+		return err
+	}
+
+	if err = common.AttachIfaceToBridge(ovsBridgeDriver,
+		hostIface.Name,
+		contIface.Name,
+		netconf.OfportRequest,
+		portCfg.VlanTag,
+		portCfg.Trunks,
+		portCfg.Type,
+		netconf.InterfaceType,
+		args.Netns,
+		ovnPort,
+		contPodUid,
+	); err != nil {
+		// Unlike veth pair, OVS port will not be automatically removed
+		// if the following IPAM configuration fails and netns gets removed.
+		_, _, cleanupErr := common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+		if cleanupErr != nil {
+			log.Printf("Failed best-effort cleanup: %v", cleanupErr)
+		}
+		return err
+	}
+
+	result := &current.Result{
+		Interfaces: []*current.Interface{hostIface, contIface},
+	}
+
+	return cnitypes.PrintResult(result, netconf.CNIVersion)
+}
+
+func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+	var ovnPort string
+	if envArgs != nil {
+		ovnPort = string(envArgs.OvnPort)
+	}
+	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+	bridgeName, err := sriov.GetBridgeName(ovsDriver, cache.Netconf.BrName, ovnPort, cache.Netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, cache.Netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	// The CNI_NETNS parameter may be empty according to version 0.4.0
+	// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
+	if args.Netns == "" {
+		// SR-IOV Case - The sriov device is moved into host network namespace when args.Netns is empty.
+		// This happens container is killed due to an error (example: CrashLoopBackOff, OOMKilled)
+		var rep string
+		if rep, err = sriov.GetNetRepresentor(cache.Netconf.DeviceID); err != nil {
+			return err
+		}
+		if err = common.RemoveOvsPort(ovsBridgeDriver, rep); err != nil {
+			// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
+			// port is already deleted in a previous invocation.
+			log.Printf("Error: %v\n", err)
+		}
+		return nil
+	}
+
+	// Unlike veth pair, OVS port will not be automatically removed when
+	// container namespace is gone. Find port matching DEL arguments and remove
+	// it explicitly.
+	_, _, err = common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+	if err != nil {
+		return err
+	}
+
+	// removes all ports whose interfaces have an error
+	return common.CleanPorts(ovsBridgeDriver)
+}
+
+func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+	var ovnPort string
+	if envArgs != nil {
+		ovnPort = string(envArgs.OvnPort)
+	}
+
+	// Discover bridge name using SR-IOV specific logic
+	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+	bridgeName, err := sriov.GetBridgeName(ovsDriver, netconf.BrName, ovnPort, netconf.DeviceID)
+	if err != nil {
+		return err
+	}
+	netconf.BrName = bridgeName
+
+	cache, err := common.CacheLoadAndCheck(args, netconf)
+	if err != nil {
+		return err
+	}
+
+	result, err := common.ParsePrevResult(netconf)
+	if err != nil {
+		return err
+	}
+
+	hostIntf, contIntf, err := common.ExtractInterfaces(args, result, true)
+	if err != nil {
+		return err
+	}
+
+	err = validateVdpaDevice(contIntf, netconf.DeviceID, cache.VdpaType)
+	if err != nil {
+		return err
+	}
+
+	// ovs specific check
+	return common.ValidateOvs(args, netconf, hostIntf.Name)
+}

--- a/pkg/vdpa/vdpa.go
+++ b/pkg/vdpa/vdpa.go
@@ -70,6 +70,15 @@ func getVdpaMacAddr(vdpaDevice *kvdpa.VdpaDevice) (net.HardwareAddr, error) {
 	return cfg.Net.Cfg.MACAddr, nil
 }
 
+func getVdpaMTU(vdpaDevice *kvdpa.VdpaDevice) (uint16, error) {
+	cfg, err := netlink.VDPAGetDevConfigByName((*vdpaDevice).Name())
+	if err != nil {
+		return 0, err
+	}
+
+	return cfg.Net.Cfg.MTU, nil
+}
+
 func SetupVdpaInterface(
 	contNetns ns.NetNS,
 	ifName,
@@ -162,4 +171,67 @@ func setupKernelVdpaVhost(
 	contIface.Sandbox = contNetns.Path()
 
 	return hostIface, contIface, nil
+}
+
+func ValidateVdpaDevice(intf current.Interface, pciAddr string, vdpaType types.VdpaDeviceType) error {
+	switch vdpaType {
+	case types.VdpaDeviceTypeNone:
+		return fmt.Errorf("non-vdpa devices can not be configured as such")
+	case types.VdpaDeviceTypeKernelVhost:
+		return validateKernelVdpaVhost(intf, pciAddr)
+	default:
+		return fmt.Errorf("unknown vdpa device type")
+	}
+}
+
+func validateKernelVdpaVhost(intf current.Interface, pciAddr string) error {
+	vdpaDev, err := GetVdpaDeviceFromID(pciAddr)
+	if err != nil {
+		return err
+	}
+
+	if intf.Mac != "" {
+		macAddr, err := getVdpaMacAddr(vdpaDev)
+		if err != nil {
+			return err
+		}
+
+		if intf.Mac != macAddr.String() {
+			return fmt.Errorf(
+				"Interface %s Mac %s does not match %s Mac: %s",
+				intf.Name, intf.Mac, (*vdpaDev).Name(), macAddr.String(),
+			)
+		}
+	}
+
+	if intf.Mtu != 0 {
+		mtu, err := getVdpaMTU(vdpaDev)
+		if err != nil {
+			return err
+		}
+		if intf.Mtu != int(mtu) {
+			return fmt.Errorf(
+				"Interface %s MTU %d does not match %s MTU: %d",
+				intf.Name, intf.Mtu, (*vdpaDev).Name(), mtu,
+			)
+		}
+
+		vfNetName, err := sriov.GetNetVF(pciAddr)
+		if err != nil {
+			return err
+		}
+		vfLink, err := netlink.LinkByName(vfNetName)
+		if err != nil {
+			return err
+		}
+		vfMtu := vfLink.Attrs().MTU
+		if intf.Mtu != vfMtu {
+			return fmt.Errorf(
+				"Interface %s MTU %d does not match %s MTU: %d",
+				intf.Name, intf.Mtu, vfNetName, vfMtu,
+			)
+		}
+	}
+
+	return nil
 }

--- a/pkg/vdpa/vdpa.go
+++ b/pkg/vdpa/vdpa.go
@@ -1,0 +1,165 @@
+package vdpa
+
+import (
+	"fmt"
+	"net"
+
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+)
+
+func pciAddressFrom(deviceID string) string {
+	return fmt.Sprintf("pci/%s", deviceID)
+}
+
+func GetVdpaDeviceFromID(deviceID string) (*kvdpa.VdpaDevice, error) {
+	// Don't panic if the device is not vdpa
+	if deviceID == "" {
+		return nil, nil
+	}
+
+	var vdpaDev *kvdpa.VdpaDevice
+	vdpaDevs, err := kvdpa.GetVdpaDevicesByPciAddress(pciAddressFrom(deviceID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to run vdpa netlink command")
+	}
+
+	if len(vdpaDevs) == 1 {
+		vdpaDev = &vdpaDevs[0]
+	} else if len(vdpaDevs) > 1 {
+		return nil, fmt.Errorf("multiple vdpa devices attached to the same pci mgmt device are not supported")
+	}
+
+	return vdpaDev, nil
+}
+
+func GetDeviceType(vdpaDev *kvdpa.VdpaDevice) (types.VdpaDeviceType, error) {
+	if vdpaDev == nil {
+		return types.VdpaDeviceTypeNone, nil
+	}
+
+	switch (*vdpaDev).Driver() {
+	case kvdpa.VhostVdpaDriver:
+		return types.VdpaDeviceTypeKernelVhost, nil
+	default:
+		return types.VdpaDeviceTypeNone, fmt.Errorf("unknown vdpa device type")
+	}
+}
+
+func DeviceIDToVdpaType(deviceID string) (types.VdpaDeviceType, error) {
+	vdpaDev, err := GetVdpaDeviceFromID(deviceID)
+	if err != nil {
+		return types.VdpaDeviceTypeNone, err
+	}
+	return GetDeviceType(vdpaDev)
+}
+
+func getVdpaMacAddr(vdpaDevice *kvdpa.VdpaDevice) (net.HardwareAddr, error) {
+	cfg, err := netlink.VDPAGetDevConfigByName((*vdpaDevice).Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.Net.Cfg.MACAddr, nil
+}
+
+func SetupVdpaInterface(
+	contNetns ns.NetNS,
+	ifName,
+	deviceID,
+	mac string,
+	vdpaDevice *kvdpa.VdpaDevice,
+	mtu int,
+) (*current.Interface, *current.Interface, error) {
+	vdpaDeviceType, err := GetDeviceType(vdpaDevice)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch vdpaDeviceType {
+	case types.VdpaDeviceTypeNone:
+		return nil, nil, fmt.Errorf("non-vdpa devices can not be configured as such")
+	case types.VdpaDeviceTypeKernelVhost:
+		return setupKernelVdpaVhost(contNetns, ifName, deviceID, mac, vdpaDevice, mtu)
+	default:
+		return nil, nil, fmt.Errorf("unknown vdpa device type")
+	}
+}
+
+func setupKernelVdpaVhost(
+	contNetns ns.NetNS,
+	ifName,
+	deviceID,
+	mac string,
+	vdpaDevice *kvdpa.VdpaDevice,
+	mtu int,
+) (*current.Interface, *current.Interface, error) {
+	hostIface := &current.Interface{}
+	contIface := &current.Interface{}
+
+	// network representor device for smartvf
+	rep, err := sriov.GetNetRepresentor(deviceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	hostIface.Name = rep
+
+	repLink, err := netlink.LinkByName(hostIface.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	hostIface.Mac = repLink.Attrs().HardwareAddr.String()
+
+	// parse MAC address if provided from args as described
+	// in the CNI spec (https://github.com/containernetworking/cni/blob/main/CONVENTIONS.md)
+	var hwaddr net.HardwareAddr
+	if mac != "" {
+		hwaddr, err = net.ParseMAC(mac)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse MAC address %q: %v", mac, err)
+		}
+	}
+
+	// If provided, set it to the vdpa device, not the VF
+	if hwaddr != nil {
+		if err := kvdpa.SetVdpaDeviceMac((*vdpaDevice).Name(), hwaddr); err != nil {
+			return nil, nil, err
+		}
+		contIface.Mac = mac
+	} else {
+		vdpaMacAddr, err := getVdpaMacAddr(vdpaDevice)
+		if err != nil {
+			return nil, nil, err
+		}
+		contIface.Mac = vdpaMacAddr.String()
+	}
+
+	if mtu != 0 {
+		if err = netlink.LinkSetMTU(repLink, mtu); err != nil {
+			return nil, nil, err
+		}
+
+		vfNetName, err := sriov.GetNetVF(deviceID)
+		if err != nil {
+			return nil, nil, err
+		}
+		vfLink, err := netlink.LinkByName(vfNetName)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err = netlink.LinkSetMTU(vfLink, mtu); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	contIface.Name = ifName
+	contIface.Sandbox = contNetns.Path()
+
+	return hostIface, contIface, nil
+}

--- a/pkg/vdpa/vdpa.go
+++ b/pkg/vdpa/vdpa.go
@@ -1,0 +1,255 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdpa
+
+import (
+	"fmt"
+	"net"
+
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/sriov"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+)
+
+func IsVdpa(deviceInfo *netv1.DeviceInfo) bool {
+	return deviceInfo != nil &&
+		deviceInfo.Type == netv1.DeviceInfoTypeVDPA &&
+		deviceInfo.Vdpa != nil
+}
+
+func CachedDeviceIsVdpa(cache *types.CachedNetConf) bool {
+	return cache.VdpaType != types.VdpaDeviceTypeNone
+}
+
+func pciAddressFrom(deviceID string) string {
+	return fmt.Sprintf("pci/%s", deviceID)
+}
+
+func getVdpaDeviceFromID(deviceID string) (*kvdpa.VdpaDevice, error) {
+	// Don't panic if the device is not vdpa
+	if deviceID == "" {
+		return nil, nil
+	}
+
+	var vdpaDev *kvdpa.VdpaDevice
+	vdpaDevs, err := kvdpa.GetVdpaDevicesByPciAddress(pciAddressFrom(deviceID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get devices for PCI address %q: %w", deviceID, err)
+	}
+
+	if len(vdpaDevs) == 1 {
+		vdpaDev = &vdpaDevs[0]
+	} else if len(vdpaDevs) > 1 {
+		return nil, fmt.Errorf("multiple vdpa devices attached to the same pci mgmt device are not supported")
+	} else {
+		return nil, fmt.Errorf("could not find vdpa devices assigned to mgmt device %q", deviceID)
+	}
+
+	return vdpaDev, nil
+}
+
+func getDeviceType(vdpaDev *kvdpa.VdpaDevice) (types.VdpaDeviceType, error) {
+	if vdpaDev == nil {
+		return types.VdpaDeviceTypeNone, nil
+	}
+
+	switch driver := (*vdpaDev).Driver(); driver {
+	case kvdpa.VhostVdpaDriver:
+		return types.VdpaDeviceTypeKernelVhost, nil
+	default:
+		return types.VdpaDeviceTypeNone, fmt.Errorf("unknown vdpa device type: %q", driver)
+	}
+}
+
+func getVdpaMTU(vdpaDevice *kvdpa.VdpaDevice) (uint16, error) {
+	cfg, err := netlink.VDPAGetDevConfigByName((*vdpaDevice).Name())
+	if err != nil {
+		return 0, err
+	}
+
+	return cfg.Net.Cfg.MTU, nil
+}
+
+func getVdpaMacAddr(vdpaDevice *kvdpa.VdpaDevice) (net.HardwareAddr, error) {
+	cfg, err := netlink.VDPAGetDevConfigByName((*vdpaDevice).Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.Net.Cfg.MACAddr, nil
+}
+
+func setupVdpaInterface(
+	contNetns ns.NetNS,
+	ifName,
+	deviceID,
+	mac string,
+	vdpaDevice *kvdpa.VdpaDevice,
+	mtu int,
+) (*current.Interface, *current.Interface, error) {
+	vdpaDeviceType, err := getDeviceType(vdpaDevice)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch vdpaDeviceType {
+	case types.VdpaDeviceTypeNone:
+		return nil, nil, fmt.Errorf("non-vdpa devices can not be configured as such")
+	case types.VdpaDeviceTypeKernelVhost:
+		return setupKernelVdpaVhost(contNetns, ifName, deviceID, mac, vdpaDevice, mtu)
+	default:
+		return nil, nil, fmt.Errorf("unknown vdpa device type")
+	}
+}
+
+func setupKernelVdpaVhost(
+	contNetns ns.NetNS,
+	ifName,
+	deviceID,
+	mac string,
+	vdpaDevice *kvdpa.VdpaDevice,
+	mtu int,
+) (*current.Interface, *current.Interface, error) {
+	hostIface := &current.Interface{}
+	contIface := &current.Interface{}
+
+	// network representor device for smartvf
+	rep, err := sriov.GetNetRepresentor(deviceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	hostIface.Name = rep
+
+	repLink, err := netlink.LinkByName(hostIface.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	hostIface.Mac = repLink.Attrs().HardwareAddr.String()
+
+	// parse MAC address if provided from args as described
+	// in the CNI spec (https://github.com/containernetworking/cni/blob/main/CONVENTIONS.md)
+	var hwaddr net.HardwareAddr
+	if mac != "" {
+		hwaddr, err = net.ParseMAC(mac)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse MAC address %q: %v", mac, err)
+		}
+	}
+
+	// If provided, set it to the vdpa device, not the VF
+	if hwaddr != nil {
+		if err := kvdpa.SetVdpaDeviceMac((*vdpaDevice).Name(), hwaddr); err != nil {
+			return nil, nil, err
+		}
+		contIface.Mac = mac
+	} else {
+		vdpaMacAddr, err := getVdpaMacAddr(vdpaDevice)
+		if err != nil {
+			return nil, nil, err
+		}
+		contIface.Mac = vdpaMacAddr.String()
+	}
+
+	if mtu != 0 {
+		if err = netlink.LinkSetMTU(repLink, mtu); err != nil {
+			return nil, nil, err
+		}
+
+		vfNetName, err := sriov.GetNetVF(deviceID)
+		if err != nil {
+			return nil, nil, err
+		}
+		vfLink, err := netlink.LinkByName(vfNetName)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err = netlink.LinkSetMTU(vfLink, mtu); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	contIface.Name = ifName
+	contIface.Sandbox = contNetns.Path()
+
+	return hostIface, contIface, nil
+}
+
+func validateVdpaDevice(intf current.Interface, pciAddr string, vdpaType types.VdpaDeviceType) error {
+	switch vdpaType {
+	case types.VdpaDeviceTypeNone:
+		return fmt.Errorf("non-vdpa devices can not be configured as such")
+	case types.VdpaDeviceTypeKernelVhost:
+		return validateKernelVdpaVhost(intf, pciAddr)
+	default:
+		return fmt.Errorf("unknown vdpa device type")
+	}
+}
+
+func validateKernelVdpaVhost(intf current.Interface, pciAddr string) error {
+	vdpaDev, err := getVdpaDeviceFromID(pciAddr)
+	if err != nil {
+		return err
+	}
+
+	if intf.Mac != "" {
+		macAddr, err := getVdpaMacAddr(vdpaDev)
+		if err != nil {
+			return err
+		}
+
+		if intf.Mac != macAddr.String() {
+			return fmt.Errorf(
+				"Interface %s Mac %s does not match %s Mac: %s",
+				intf.Name, intf.Mac, (*vdpaDev).Name(), macAddr.String(),
+			)
+		}
+	}
+
+	if intf.Mtu != 0 {
+		mtu, err := getVdpaMTU(vdpaDev)
+		if err != nil {
+			return err
+		}
+		if intf.Mtu != int(mtu) {
+			return fmt.Errorf(
+				"Interface %s MTU %d does not match %s MTU: %d",
+				intf.Name, intf.Mtu, (*vdpaDev).Name(), mtu,
+			)
+		}
+
+		vfNetName, err := sriov.GetNetVF(pciAddr)
+		if err != nil {
+			return err
+		}
+		vfLink, err := netlink.LinkByName(vfNetName)
+		if err != nil {
+			return err
+		}
+		vfMtu := vfLink.Attrs().MTU
+		if intf.Mtu != vfMtu {
+			return fmt.Errorf(
+				"Interface %s MTU %d does not match %s MTU: %d",
+				intf.Name, intf.Mtu, vfNetName, vfMtu,
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/veth/plugin.go
+++ b/pkg/veth/plugin.go
@@ -1,0 +1,129 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package veth
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/config"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/ovsdb"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/utils"
+)
+
+func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+
+	var mac string
+	var ovnPort string
+	var contPodUid string
+	if envArgs != nil {
+		mac = string(envArgs.MAC)
+		ovnPort = string(envArgs.OvnPort)
+		contPodUid = string(envArgs.K8S_POD_UID)
+	}
+
+	portCfg, err := common.ParseOvsPortConfig(netconf)
+	if err != nil {
+		return err
+	}
+
+	bridgeName, err := common.GetBridgeName(netconf.BrName, ovnPort)
+	if err != nil {
+		return err
+	}
+	netconf.BrName = bridgeName
+
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	// removes all ports whose interfaces have an error
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
+		return err
+	}
+
+	contNetns, err := ns.GetNS(args.Netns)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	}
+	defer func() { _ = contNetns.Close() }()
+
+	// Cache NetConf for CmdDel
+	if err = utils.SaveCache(config.GetCRef(args.ContainerID, args.IfName),
+		&types.CachedNetConf{Netconf: netconf, OrigIfName: "", UserspaceMode: false}); err != nil {
+		return fmt.Errorf("error saving NetConf %q", err)
+	}
+
+	hostIface, contIface, err := SetupVeth(contNetns, args.IfName, mac, netconf.MTU)
+	if err != nil {
+		return err
+	}
+
+	if err = common.AttachIfaceToBridge(
+		ovsBridgeDriver,
+		hostIface.Name,
+		contIface.Name,
+		netconf.OfportRequest,
+		portCfg.VlanTag,
+		portCfg.Trunks,
+		portCfg.Type,
+		netconf.InterfaceType,
+		args.Netns,
+		ovnPort,
+		contPodUid,
+	); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			_, _, cleanupErr := common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+			if cleanupErr != nil {
+				log.Printf("Failed best-effort cleanup: %v", cleanupErr)
+			}
+		}
+	}()
+
+	// Refetch the host interface MAC since OVS may change it when
+	// attaching the port to the bridge.
+	if err = common.RefetchIface(hostIface); err != nil {
+		return err
+	}
+
+	result := &current.Result{
+		Interfaces: []*current.Interface{hostIface, contIface},
+	}
+
+	if netconf.IPAM.Type != "" {
+		result, err = common.ManagedIPAMAddCall(
+			ovsBridgeDriver, args, netconf, mac, hostIface, contIface, contNetns, false,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cnitypes.PrintResult(result, netconf.CNIVersion)
+}

--- a/pkg/veth/plugin.go
+++ b/pkg/veth/plugin.go
@@ -194,3 +194,36 @@ func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
 
 	return err
 }
+
+func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+	var ovnPort string
+	if envArgs != nil {
+		ovnPort = string(envArgs.OvnPort)
+	}
+
+	// Discover bridge name
+	bridgeName, err := common.GetBridgeName(netconf.BrName, ovnPort)
+	if err != nil {
+		return err
+	}
+	netconf.BrName = bridgeName
+
+	// check cache
+	cache, err := common.CacheLoadAndCheck(args, netconf)
+	if err != nil {
+		return err
+	}
+
+	// run the IPAM plugin
+	if netconf.NetConf.IPAM.Type != "" {
+		if err := ipam.ExecCheck(netconf.NetConf.IPAM.Type, args.StdinData); err != nil {
+			return fmt.Errorf("failed to check with IPAM plugin type %q: %v", netconf.NetConf.IPAM.Type, err)
+		}
+	}
+
+	return common.ValidateAttachment(args, netconf, cache)
+}

--- a/pkg/veth/plugin.go
+++ b/pkg/veth/plugin.go
@@ -19,6 +19,8 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
@@ -126,4 +128,69 @@ func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
 	}
 
 	return cnitypes.PrintResult(result, netconf.CNIVersion)
+}
+
+func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
+	envArgs, err := common.GetEnvArgs(args.Args)
+	if err != nil {
+		return err
+	}
+
+	var ovnPort string
+	if envArgs != nil {
+		ovnPort = string(envArgs.OvnPort)
+	}
+
+	bridgeName, err := common.GetBridgeName(cache.Netconf.BrName, ovnPort)
+	if err != nil {
+		return err
+	}
+
+	ovsBridgeDriver, err := ovsdb.NewOvsBridgeDriver(bridgeName, cache.Netconf.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	if cache.Netconf.IPAM.Type != "" {
+		err = ipam.ExecDel(cache.Netconf.IPAM.Type, args.StdinData)
+		if err != nil {
+			return err
+		}
+	}
+
+	if args.Netns == "" {
+		// The CNI_NETNS parameter may be empty according to version 0.4.0
+		// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
+		if err := common.CleanPorts(ovsBridgeDriver); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	portName, portFound, err := common.CleanupOvsPortBestEffort(ovsBridgeDriver, args.IfName, args.Netns)
+	if err != nil {
+		return err
+	}
+
+	err = ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {
+		err = ip.DelLinkByName(args.IfName)
+		return err
+	})
+	// do the following as per cni spec (i.e. Plugins should generally complete a DEL action
+	// without error even if some resources are missing)
+	if _, ok := err.(ns.NSPathNotExistErr); ok || err == ip.ErrLinkNotFound {
+		if portFound {
+			if err := ip.DelLinkByName(portName); err != nil {
+				log.Printf("Failed best-effort cleanup of %s: %v", portName, err)
+			}
+		}
+		return nil
+	}
+
+	// removes all ports whose interfaces have an error
+	if err := common.CleanPorts(ovsBridgeDriver); err != nil {
+		return err
+	}
+
+	return err
 }

--- a/pkg/veth/veth.go
+++ b/pkg/veth/veth.go
@@ -1,0 +1,71 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package veth
+
+import (
+	"github.com/vishvananda/netlink"
+
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
+)
+
+func setInterfaceUp(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func SetupVeth(contNetns ns.NetNS, contIfaceName string, requestedMac string, mtu int) (*current.Interface, *current.Interface, error) {
+	hostIface := &current.Interface{}
+	contIface := &current.Interface{}
+
+	// Enter container network namespace and create veth pair inside. Doing
+	// this we will make sure that both ends of the veth pair will be removed
+	// when the container is gone.
+	err := contNetns.Do(func(hostNetns ns.NetNS) error {
+		hostVeth, containerVeth, err := ip.SetupVeth(contIfaceName, mtu, requestedMac, hostNetns)
+		if err != nil {
+			return err
+		}
+
+		if err := setInterfaceUp(contIfaceName); err != nil {
+			return err
+		}
+
+		contIface.Name = containerVeth.Name
+		contIface.Mac = containerVeth.HardwareAddr.String()
+		contIface.Sandbox = contNetns.Path()
+		hostIface.Name = hostVeth.Name
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Refetch the hostIface since its MAC address may change during network namespace move.
+	if err = common.RefetchIface(hostIface); err != nil {
+		return nil, nil, err
+	}
+
+	return hostIface, contIface, nil
+}

--- a/tests/cni/plugin_test.go
+++ b/tests/cni/plugin_test.go
@@ -41,6 +41,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/common"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/plugin"
 	"github.com/k8snetworkplumbingwg/ovs-cni/pkg/types"
 )
@@ -219,7 +220,7 @@ var pluginTestFunc = func(version string) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(addrs)).To(Equal(1))
 			Expect(addrs[0].String()).To(HavePrefix(ipPrefix))
-			Expect(link.Attrs().HardwareAddr).To(Equal(plugin.IPAddrToHWAddr(addrs[0].IP)))
+			Expect(link.Attrs().HardwareAddr).To(Equal(common.IPAddrToHWAddr(addrs[0].IP)))
 
 			if isDual {
 				addrs, err := netlink.AddrList(link, syscall.AF_INET6)

--- a/tests/cni/plugin_test.go
+++ b/tests/cni/plugin_test.go
@@ -17,7 +17,6 @@ package cni
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -104,25 +103,6 @@ var _ = Describe("CNI Plugin 0.4.0", func() { pluginTestFunc("0.4.0") })
 var _ = Describe("CNI Plugin 1.0.0", func() { pluginTestFunc("1.0.0") })
 
 var pluginTestFunc = func(version string) {
-	testSplitVlanIds := func(conf string, expTrunks []uint, expErr error, setUnmarshalErr bool) {
-		var trunks []*types.Trunk
-		err := json.Unmarshal([]byte(conf), &trunks)
-		if setUnmarshalErr {
-			Expect(err).To(HaveOccurred())
-			return
-		}
-		Expect(err).NotTo(HaveOccurred())
-		By("Calling testSplitVlanIds method")
-		vlanIds, err := plugin.SplitVlanIds(trunks)
-		if expErr != nil {
-			By("Checking expected error is occurred")
-			Expect(err).To(Equal(expErr))
-		} else {
-			By("Checking vlanIds are same as trunk vlans")
-			Expect(vlanIds).To(Equal(expTrunks))
-		}
-	}
-
 	testCheck := func(conf string, r cnitypes.Result, targetNs ns.NetNS) {
 		if checkSupported, _ := cniversion.GreaterThanOrEqualTo(version, "0.4.0"); !checkSupported {
 			return
@@ -867,6 +847,7 @@ var pluginTestFunc = func(version string) {
 				Expect(err.Error()).To(ContainSubstring("error state"))
 			})
 		})
+
 		Context("purge ports with failed interfaces", func() {
 			conf := fmt.Sprintf(`{
 				"cniVersion": "%s",
@@ -931,45 +912,6 @@ var pluginTestFunc = func(version string) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(output)).To(
 					ContainSubstring(secondHostIface.Name), "OVS port with healthy interface should have been kept")
-			})
-		})
-	})
-
-	Context("splitVlanIds", func() {
-		Context("specify trunk with multiple ranges", func() {
-			trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 19, "maxID": 20} ]`
-			It("testSplitVlanIds method should return with specified values in the range", func() {
-				testSplitVlanIds(trunks, []uint{10, 11, 12, 19, 20}, nil, false)
-			})
-		})
-		Context("specify trunk with multiple ids", func() {
-			trunks := `[ {"id": 15}, {"id": 19}, {"id": 40} ]`
-			It("testSplitVlanIds method should return with specified id values", func() {
-				testSplitVlanIds(trunks, []uint{15, 19, 40}, nil, false)
-			})
-		})
-		Context("specify trunk with minID/maxID same value and duplicate values", func() {
-			trunks := `[ {"minID": 10, "maxID": 14}, {"id": 11}, {"minID": 13, "maxID": 13} ]`
-			It("testSplitVlanIds method should return without duplicate trunk values", func() {
-				testSplitVlanIds(trunks, []uint{10, 11, 12, 13, 14}, nil, false)
-			})
-		})
-		Context("specify trunk with negative value", func() {
-			trunks := `[ {"id": 15}, {"id": 15}, {"id": -20} ]`
-			It("testSplitVlanIds method should throw appropriate error", func() {
-				testSplitVlanIds(trunks, nil, errors.New("incorrect trunk id parameter"), true)
-			})
-		})
-		Context("specify trunk with minID greater than maxID", func() {
-			trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 11, "maxID": 5} ]`
-			It("testSplitVlanIds method should throw appropriate error", func() {
-				testSplitVlanIds(trunks, nil, errors.New("minID is greater than maxID in trunk parameter"), false)
-			})
-		})
-		Context("specify trunk with maxID greater than 4096", func() {
-			trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 1, "maxID": 5000} ]`
-			It("testSplitVlanIds method should throw appropriate error", func() {
-				testSplitVlanIds(trunks, nil, errors.New("incorrect trunk maxID parameter"), false)
 			})
 		})
 	})

--- a/tests/cni/plugin_test.go
+++ b/tests/cni/plugin_test.go
@@ -843,7 +843,7 @@ var pluginTestFunc = func(version string) {
 				netconf, err := config.LoadConf(args.StdinData)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = plugin.ValidateOvs(args, netconf, hostIfName)
+				err = common.ValidateOvs(args, netconf, hostIfName)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("error state"))
 			})

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/LICENSE
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/device.go
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/device.go
@@ -1,0 +1,348 @@
+package kvdpa
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// Exported constants
+const (
+	VhostVdpaDriver  = "vhost_vdpa"
+	VirtioVdpaDriver = "virtio_vdpa"
+)
+
+// Private constants
+const (
+	vdpaBusDevDir   = "/sys/bus/vdpa/devices"
+	vdpaVhostDevDir = "/dev"
+	rootDevDir      = "/sys/devices"
+)
+
+// VdpaDevice contains information about a Vdpa Device
+type VdpaDevice interface {
+	Driver() string
+	Name() string
+	MgmtDev() MgmtDev
+	VirtioNet() VirtioNet
+	VhostVdpa() VhostVdpa
+	ParentDevicePath() (string, error)
+}
+
+// vdpaDev implements VdpaDevice interface
+type vdpaDev struct {
+	name      string
+	driver    string
+	mgmtDev   *mgmtDev
+	virtioNet VirtioNet
+	vhostVdpa VhostVdpa
+}
+
+// Driver resturns de device's driver name
+func (vd *vdpaDev) Driver() string {
+	return vd.driver
+}
+
+// Driver resturns de device's name
+func (vd *vdpaDev) Name() string {
+	return vd.name
+}
+
+// MgmtDev returns the device's management device
+func (vd *vdpaDev) MgmtDev() MgmtDev {
+	return vd.mgmtDev
+}
+
+// VhostVdpa returns the VhostVdpa device information associated
+// or nil if the device is not bound to the vhost_vdpa driver
+func (vd *vdpaDev) VhostVdpa() VhostVdpa {
+	return vd.vhostVdpa
+}
+
+// Virtionet returns the VirtioNet device information associated
+// or nil if the device is not bound to the virtio_vdpa driver
+func (vd *vdpaDev) VirtioNet() VirtioNet {
+	return vd.virtioNet
+}
+
+// getBusInfo populates the vdpa bus information
+// the vdpa device must have at least the name prepopulated
+func (vd *vdpaDev) getBusInfo() error {
+	driverLink, err := os.Readlink(filepath.Join(vdpaBusDevDir, vd.name, "driver"))
+	if err != nil {
+		// No error if driver is not present. The device is simply not bound to any.
+		return nil
+	}
+
+	vd.driver = filepath.Base(driverLink)
+
+	switch vd.driver {
+	case VhostVdpaDriver:
+		vd.vhostVdpa, err = vd.getVhostVdpaDev()
+		if err != nil {
+			return err
+		}
+	case VirtioVdpaDriver:
+		vd.virtioNet, err = vd.getVirtioVdpaDev()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseAttributes populates the vdpa device information from netlink attributes
+func (vd *vdpaDev) parseAttributes(attrs []syscall.NetlinkRouteAttr) error {
+	mgmtDev := &mgmtDev{}
+	for _, a := range attrs {
+		switch a.Attr.Type {
+		case VdpaAttrDevName:
+			vd.name = string(a.Value[:len(a.Value)-1])
+		case VdpaAttrMgmtDevBusName:
+			mgmtDev.busName = string(a.Value[:len(a.Value)-1])
+		case VdpaAttrMgmtDevDevName:
+			mgmtDev.devName = string(a.Value[:len(a.Value)-1])
+		}
+	}
+	vd.mgmtDev = mgmtDev
+	return nil
+}
+
+/* Finds the vhost vdpa device of a vdpa device and returns it's path */
+func (vd *vdpaDev) getVhostVdpaDev() (VhostVdpa, error) {
+	// vhost vdpa devices live in the vdpa device's path
+	path := filepath.Join(vdpaBusDevDir, vd.name)
+	return GetVhostVdpaDevInPath(path)
+}
+
+/* ParentDevice returns the path of the parent device (e.g: PCI) of the device */
+func (vd *vdpaDev) ParentDevicePath() (string, error) {
+	vdpaDevicePath := filepath.Join(vdpaBusDevDir, vd.name)
+
+	/* For pci devices we have:
+	/sys/bud/vdpa/devices/vdpaX ->
+	    ../../../devices/pci0000:00/.../0000:05:00:1/vdpaX
+
+	Resolving the symlinks should give us the parent PCI device.
+	*/
+	devicePath, err := filepath.EvalSymlinks(vdpaDevicePath)
+	if err != nil {
+		return "", err
+	}
+
+	/* If the parent device is the root device /sys/devices, there is
+	no parent (e.g: vdpasim).
+	*/
+	parent := filepath.Dir(devicePath)
+	if parent == rootDevDir {
+		return devicePath, nil
+	}
+
+	return parent, nil
+}
+
+/*
+	Finds the virtio vdpa device of a vdpa device and returns its path
+
+Currently, PCI-based devices have the following sysfs structure:
+/sys/bus/vdpa/devices/
+
+	vdpa1 -> ../../../devices/pci0000:00/0000:00:03.2/0000:05:00.2/vdpa1
+
+In order to find the virtio device we look for virtio* devices inside the parent device:
+
+	sys/devices/pci0000:00/0000:00:03.2/0000:05:00.2/virtio{N}
+
+We also check the virtio device exists in the virtio bus:
+/sys/bus/virtio/devices
+
+	virtio{N} -> ../../../devices/pci0000:00/0000:00:03.2/0000:05:00.2/virtio{N}
+*/
+func (vd *vdpaDev) getVirtioVdpaDev() (VirtioNet, error) {
+	parentPath, err := vd.ParentDevicePath()
+	if err != nil {
+		return nil, err
+	}
+	return GetVirtioNetInPath(parentPath)
+}
+
+/*GetVdpaDevice returns the vdpa device information by a vdpa device name */
+func GetVdpaDevice(name string) (VdpaDevice, error) {
+	nameAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevName, name)
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := GetNetlinkOps().
+		RunVdpaNetlinkCmd(VdpaCmdDevGet, 0, []*nl.RtAttr{nameAttr})
+	if err != nil {
+		return nil, err
+	}
+
+	// No filters, expecting to parse attributes for the device with the given name
+	vdpaDevs, err := parseDevLinkVdpaDevList("", "", msgs)
+	if err != nil {
+		return nil, err
+	}
+	return vdpaDevs[0], nil
+}
+
+/*
+GetVdpaDevicesByMgmtDev returns the VdpaDevice objects whose MgmtDev
+has the given bus and device names.
+*/
+func GetVdpaDevicesByMgmtDev(busName, devName string) ([]VdpaDevice, error) {
+	return listVdpaDevicesWithBusDevName(busName, devName)
+}
+
+/*ListVdpaDevices returns a list of all available vdpa devices */
+func ListVdpaDevices() ([]VdpaDevice, error) {
+	return listVdpaDevicesWithBusDevName("", "")
+}
+
+func listVdpaDevicesWithBusDevName(busName, devName string) ([]VdpaDevice, error) {
+	msgs, err := GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdDevGet, syscall.NLM_F_DUMP, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	vdpaDevs, err := parseDevLinkVdpaDevList(busName, devName, msgs)
+	if err != nil {
+		return nil, err
+	}
+	return vdpaDevs, nil
+}
+
+/*
+GetVdpaDevicesByPciAddress returns the VdpaDevice objects for the given pciAddress
+
+	The pciAddress must have one of the following formats:
+	- MgmtBusName/MgmtDevName
+	- MgmtDevName
+*/
+func GetVdpaDevicesByPciAddress(pciAddress string) ([]VdpaDevice, error) {
+	busName, mgmtDeviceName, err := ExtractBusAndMgmtDevice(pciAddress)
+	if err != nil {
+		return nil, unix.EINVAL
+	}
+
+	return GetVdpaDevicesByMgmtDev(busName, mgmtDeviceName)
+}
+
+/*AddVdpaDevice adds a new vdpa device to the given management device */
+func AddVdpaDevice(mgmtDeviceName string, vdpaDeviceName string) error {
+	if mgmtDeviceName == "" || vdpaDeviceName == "" {
+		return unix.EINVAL
+	}
+
+	busName, mgmtDeviceName, err := ExtractBusAndMgmtDevice(mgmtDeviceName)
+	if err != nil {
+		return unix.EINVAL
+	}
+
+	var attributes []*nl.RtAttr
+	var busNameAttr *nl.RtAttr
+	if busName != "" {
+		busNameAttr, err = GetNetlinkOps().NewAttribute(VdpaAttrMgmtDevBusName, busName)
+		if err != nil {
+			return err
+		}
+		attributes = append(attributes, busNameAttr)
+	}
+
+	mgmtAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrMgmtDevDevName, mgmtDeviceName)
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, mgmtAttr)
+
+	nameAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevName, vdpaDeviceName)
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, nameAttr)
+
+	_, err = GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdDevNew, unix.NLM_F_ACK|unix.NLM_F_REQUEST, attributes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*DeleteVdpaDevice deletes a vdpa device */
+func DeleteVdpaDevice(vdpaDeviceName string) error {
+	if vdpaDeviceName == "" {
+		return unix.EINVAL
+	}
+
+	nameAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevName, vdpaDeviceName)
+	if err != nil {
+		return err
+	}
+
+	_, err = GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdDevDel, unix.NLM_F_ACK|unix.NLM_F_REQUEST, []*nl.RtAttr{nameAttr})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseDevLinkVdpaDevList(busName string, mgmtDeviceName string, msgs [][]byte) ([]VdpaDevice, error) {
+	devices := make([]VdpaDevice, 0, len(msgs))
+
+	for _, m := range msgs {
+		attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])
+		if err != nil {
+			return nil, err
+		}
+		dev := &vdpaDev{}
+		if err = dev.parseAttributes(attrs); err != nil {
+			return nil, err
+		}
+
+		if busName != "" && busName != dev.mgmtDev.busName {
+			continue
+		}
+
+		if mgmtDeviceName != "" && mgmtDeviceName != dev.mgmtDev.devName {
+			continue
+		}
+
+		if err = dev.getBusInfo(); err != nil {
+			return nil, err
+		}
+		devices = append(devices, dev)
+	}
+	return devices, nil
+}
+
+// SetVdpaDeviceMac sets a new mac address to an existing vdpa device
+func SetVdpaDeviceMac(vdpaDeviceName string, mac net.HardwareAddr) error {
+	var attributes []*nl.RtAttr
+
+	if vdpaDeviceName == "" || len(mac) == 0 {
+		return unix.EINVAL
+	}
+
+	nameAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevName, vdpaDeviceName)
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, nameAttr)
+
+	macAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevNetCfgMacAddr, mac)
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, macAttr)
+	_, err = GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdDevAttrSet, unix.NLM_F_ACK|unix.NLM_F_REQUEST, attributes)
+
+	return err
+}

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/mgmtdev.go
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/mgmtdev.go
@@ -1,0 +1,111 @@
+package kvdpa
+
+import (
+	"strings"
+	"syscall"
+
+	"github.com/vishvananda/netlink/nl"
+)
+
+// MgmtDev represents a Vdpa Management Device
+type MgmtDev interface {
+	BusName() string // Optional
+	DevName() string //
+	Name() string    // The MgmtDevName is BusName/DevName
+}
+
+type mgmtDev struct {
+	busName string
+	devName string
+}
+
+// BusName returns the MgmtDev's bus name
+func (m *mgmtDev) BusName() string {
+	return m.busName
+}
+
+// BusName returns the MgmtDev's device name
+func (m *mgmtDev) DevName() string {
+	return m.devName
+}
+
+// BusName returns the MgmtDev's name: [BusName/]DeviceName
+func (m *mgmtDev) Name() string {
+	if m.busName != "" {
+		return strings.Join([]string{m.busName, m.devName}, "/")
+	}
+	return m.devName
+}
+
+// parseAttributes parses the netlink attributes and populates the fields accordingly
+func (m *mgmtDev) parseAttributes(attrs []syscall.NetlinkRouteAttr) error {
+	for _, a := range attrs {
+		switch a.Attr.Type {
+		case VdpaAttrMgmtDevBusName:
+			m.busName = string(a.Value[:len(a.Value)-1])
+		case VdpaAttrMgmtDevDevName:
+			m.devName = string(a.Value[:len(a.Value)-1])
+		}
+	}
+	return nil
+}
+
+// ListVdpaMgmtDevices returns the list of all available MgmtDevs
+func ListVdpaMgmtDevices() ([]MgmtDev, error) {
+	msgs, err := GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdMgmtDevGet, syscall.NLM_F_DUMP, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	mgtmDevs, err := parseDevLinkVdpaMgmtDevList(msgs)
+	if err != nil {
+		return nil, err
+	}
+	return mgtmDevs, nil
+}
+
+// GetVdpaMgmtDevices returns a MgmtDev based on a busName and deviceName
+func GetVdpaMgmtDevices(busName, devName string) (MgmtDev, error) {
+	data := []*nl.RtAttr{}
+	if busName != "" {
+		bus, err := GetNetlinkOps().NewAttribute(VdpaAttrMgmtDevBusName, busName)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, bus)
+	}
+
+	dev, err := GetNetlinkOps().NewAttribute(VdpaAttrMgmtDevDevName, devName)
+	if err != nil {
+		return nil, err
+	}
+	data = append(data, dev)
+
+	msgs, err := GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdMgmtDevGet, 0, data)
+	if err != nil {
+		return nil, err
+	}
+
+	mgtmDevs, err := parseDevLinkVdpaMgmtDevList(msgs)
+	if err != nil {
+		return nil, err
+	}
+	return mgtmDevs[0], nil
+}
+
+func parseDevLinkVdpaMgmtDevList(msgs [][]byte) ([]MgmtDev, error) {
+	devices := make([]MgmtDev, 0, len(msgs))
+
+	for _, m := range msgs {
+		attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])
+		if err != nil {
+			return nil, err
+		}
+		dev := &mgmtDev{}
+		if err = dev.parseAttributes(attrs); err != nil {
+			return nil, err
+		}
+		devices = append(devices, dev)
+	}
+	return devices, nil
+}

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/netlink.go
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/netlink.go
@@ -1,0 +1,190 @@
+package kvdpa
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+)
+
+/* Vdpa Netlink Name */
+const (
+	VdpaGenlName = "vdpa"
+)
+
+/* VDPA Netlink Commands */
+const (
+	VdpaCmdUnspec uint8 = iota
+	VdpaCmdMgmtDevNew
+	VdpaCmdMgmtDevGet /* can dump */
+	VdpaCmdDevNew
+	VdpaCmdDevDel
+	VdpaCmdDevGet       /* can dump */
+	VdpaCmdDevConfigGet /* can dump */
+	VdpaCmdDevVStatsGet
+	VdpaCmdDevAttrSet
+)
+
+/* VDPA Netlink Attributes */
+const (
+	VdpaAttrUnspec = iota
+
+	/* bus name (optional) + dev name together make the parent device handle */
+	VdpaAttrMgmtDevBusName          /* string */
+	VdpaAttrMgmtDevDevName          /* string */
+	VdpaAttrMgmtDevSupportedClasses /* u64 */
+
+	VdpaAttrDevName      /* string */
+	VdpaAttrDevID        /* u32 */
+	VdpaAttrDevVendorID  /* u32 */
+	VdpaAttrDevMaxVqs    /* u32 */
+	VdpaAttrDevMaxVqSize /* u16 */
+	VdpaAttrDevMinVqSize /* u16 */
+
+	VdpaAttrDevNetCfgMacAddr /* binary */
+	VdpaAttrDevNetStatus     /* u8 */
+	VdpaAttrDevNetCfgMaxVqp  /* u16 */
+	VdpaAttrGetNetCfgMTU     /* u16 */
+
+	/* new attributes must be added above here */
+	VdpaAttrMax
+)
+
+var (
+	commonNetlinkFlags = syscall.NLM_F_REQUEST | syscall.NLM_F_ACK
+)
+
+// NetlinkOps defines the Netlink Operations
+type NetlinkOps interface {
+	RunVdpaNetlinkCmd(command uint8, flags int, data []*nl.RtAttr) ([][]byte, error)
+	NewAttribute(attrType int, data interface{}) (*nl.RtAttr, error)
+}
+
+type defaultNetlinkOps struct {
+}
+
+var netlinkOps NetlinkOps = &defaultNetlinkOps{}
+
+// SetNetlinkOps method would be used by unit tests
+func SetNetlinkOps(mockInst NetlinkOps) {
+	netlinkOps = mockInst
+}
+
+// GetNetlinkOps will be invoked by functions in other packages that would need access to the sriovnet library methods.
+func GetNetlinkOps() NetlinkOps {
+	return netlinkOps
+}
+
+// RunVdpaNerlinkCmd runs a vdpa netlink command and returns the response
+func (defaultNetlinkOps) RunVdpaNetlinkCmd(command uint8, flags int, data []*nl.RtAttr) ([][]byte, error) {
+	f, err := netlink.GenlFamilyGet(VdpaGenlName)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &nl.Genlmsg{
+		Command: command,
+		Version: nl.GENL_CTRL_VERSION,
+	}
+	req := nl.NewNetlinkRequest(int(f.ID), commonNetlinkFlags|flags)
+
+	req.AddData(msg)
+	for _, d := range data {
+		req.AddData(d)
+	}
+
+	msgs, err := req.Execute(syscall.NETLINK_GENERIC, 0)
+	if err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+// NewAttribute returns a new netlink attribute based on the provided data
+func (defaultNetlinkOps) NewAttribute(attrType int, data interface{}) (*nl.RtAttr, error) {
+	switch attrType {
+	case VdpaAttrMgmtDevBusName, VdpaAttrMgmtDevDevName, VdpaAttrDevName:
+		strData, ok := data.(string)
+		if !ok {
+			return nil, fmt.Errorf("attribute type %d requires string data", attrType)
+		}
+		bytes := make([]byte, len(strData)+1)
+		copy(bytes, strData)
+		return nl.NewRtAttr(attrType, bytes), nil
+	case VdpaAttrDevNetCfgMacAddr:
+		macData, ok := data.(net.HardwareAddr)
+		if !ok {
+			return nil, fmt.Errorf("attribute type %d requires encoded data", attrType)
+		}
+		return nl.NewRtAttr(attrType, macData), nil
+		/* TODO
+		case:
+		    VdpaAttrMgmtDevBusName          string
+		    VdpaAttrMgmtDevDevName           string
+		    VdpaAttrMgmtDevSupportedClasses  u64
+
+		    VdpaAttrDevName       string
+		    VdpaAttrDevID         u32
+		    VdpaAttrDevVendorID   u32
+		    VdpaAttrDevMaxVqs     u32
+		    VdpaAttrDevMaxVqSize  u16
+		    VdpaAttrDevMinVqSize  u16
+
+		    VdpaAttrDevNetStatus      u8
+		    VdpaAttrDevNetCfgMaxVqp   u16
+		    VdpaAttrGetNetCfgMTU      u16
+		*/
+	default:
+		return nil, fmt.Errorf("invalid attribute type %d", attrType)
+	}
+
+}
+
+func newMockSingleMessage(command uint8, attrs []*nl.RtAttr) []byte {
+	b := make([]byte, 0)
+	dataBytes := make([][]byte, len(attrs)+1)
+
+	msg := &nl.Genlmsg{
+		Command: command,
+		Version: nl.GENL_CTRL_VERSION,
+	}
+	dataBytes[0] = msg.Serialize()
+
+	for i, attr := range attrs {
+		dataBytes[i+1] = attr.Serialize()
+	}
+	next := 0
+	for _, data := range dataBytes {
+		for _, dataByte := range data {
+			b = append(b, dataByte)
+			next = next + 1
+		}
+	}
+	return b
+	/*
+		nlm := &nl.NetlinkRequest{
+			NlMsghdr: unix.NlMsghdr{
+				Len:   uint32(unix.SizeofNlMsghdr),
+				Type:  0xa,
+				Flags: 0,
+				Seq:   1,
+			},
+		}
+		for _, a := range attrs {
+			nlm.AddData(a)
+		}
+		return nlm.Serialize()
+	*/
+}
+
+// Used for unit tests
+func newMockNetLinkResponse(command uint8, data [][]*nl.RtAttr) [][]byte {
+	msgs := make([][]byte, len(data))
+	for i, msgData := range data {
+		msgDataBytes := newMockSingleMessage(command, msgData)
+		msgs[i] = msgDataBytes
+	}
+	return msgs
+}

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/util.go
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/util.go
@@ -1,0 +1,22 @@
+package kvdpa
+
+import (
+	"errors"
+	"strings"
+)
+
+// ExtractBusAndMgmtDevice extracts the busName and deviceName from a full device address (e.g. pci)
+// example 1: pci/65:0000.1   -> "pci", "65:0000.1",  nil
+// example 2: vdpa_sim        -> "",    "vdpa_sim",   nil
+// example 3: pci/65:0000.1/1 -> "",    "",           err
+func ExtractBusAndMgmtDevice(fullMgmtDeviceName string) (busName string, mgmtDeviceName string, err error) {
+	numSlashes := strings.Count(fullMgmtDeviceName, "/")
+	if numSlashes > 1 {
+		return "", "", errors.New("expected mgmtDeviceName to be either in the format <mgmtBusName>/<mgmtDeviceName> or <mgmtDeviceName>")
+	} else if numSlashes == 0 {
+		return "", fullMgmtDeviceName, nil
+	} else {
+		values := strings.Split(fullMgmtDeviceName, "/")
+		return values[0], values[1], nil
+	}
+}

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/vhost.go
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/vhost.go
@@ -1,0 +1,62 @@
+package kvdpa
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// VhostVdpa is the vhost-vdpa device information
+type VhostVdpa interface {
+	Name() string
+	Path() string
+}
+
+// vhostVdpa implements VhostVdpa interface
+type vhostVdpa struct {
+	name string
+	path string
+}
+
+// Name returns the vhost device's name
+func (v *vhostVdpa) Name() string {
+	return v.name
+}
+
+// Name returns the vhost device's path
+func (v *vhostVdpa) Path() string {
+	return v.path
+}
+
+// GetVhostVdpaDevInPath returns the VhostVdpa found in the provided parent device's path
+func GetVhostVdpaDevInPath(parentPath string) (VhostVdpa, error) {
+	fd, err := os.Open(parentPath)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	fileInfos, err := fd.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range fileInfos {
+		if strings.Contains(file.Name(), "vhost-vdpa") &&
+			file.IsDir() {
+			devicePath := filepath.Join(vdpaVhostDevDir, file.Name())
+			info, err := os.Stat(devicePath)
+			if err != nil {
+				return nil, err
+			}
+			if info.Mode()&os.ModeDevice == 0 {
+				return nil, fmt.Errorf("vhost device %s is not a valid device", devicePath)
+			}
+			return &vhostVdpa{
+				name: file.Name(),
+				path: devicePath,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no VhostVdpa device foiund in path  %s", parentPath)
+}

--- a/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/virtio.go
+++ b/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/virtio.go
@@ -1,0 +1,68 @@
+package kvdpa
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	virtioDevDir = "/sys/bus/virtio/devices"
+)
+
+// VirtioNet is the virtio-net device information
+type VirtioNet interface {
+	Name() string
+	NetDev() string
+}
+
+// virtioNet implements VirtioNet interface
+type virtioNet struct {
+	name   string
+	netDev string
+}
+
+// Name returns the virtio device's name (as appears in the virtio bus)
+func (v *virtioNet) Name() string {
+	return v.name
+}
+
+// NetDev returns the virtio-net netdev name
+func (v *virtioNet) NetDev() string {
+	return v.netDev
+}
+
+// GetVirtioNetInPath returns the VirtioNet found in the provided parent device's path
+func GetVirtioNetInPath(parentPath string) (VirtioNet, error) {
+	fd, err := os.Open(parentPath)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	fileInfos, err := fd.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range fileInfos {
+		if strings.Contains(file.Name(), "virtio") &&
+			file.IsDir() {
+			virtioDevPath := filepath.Join(virtioDevDir, file.Name())
+			if _, err := os.Stat(virtioDevPath); os.IsNotExist(err) {
+				return nil, fmt.Errorf("virtio device %s does not exist", virtioDevPath)
+			}
+			var netdev string
+			// Read the "net" directory in the virtio device path
+			netDeviceFiles, err := os.ReadDir(filepath.Join(virtioDevPath, "net"))
+			if err == nil && len(netDeviceFiles) == 1 {
+				netdev = strings.TrimSpace(netDeviceFiles[0].Name())
+			}
+			return &virtioNet{
+				name:   file.Name(),
+				netDev: netdev,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no VirtioNet device found in path %s", parentPath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,6 +124,9 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
+# github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20260114172534-639773118e4f
+## explicit; go 1.24.0
+github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa
 # github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 ## explicit; go 1.21
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io


### PR DESCRIPTION
This PR adds support for vhost_vdpa devices to ovs-cni.

Most of the steps needed to set up a vhost_vdpa device are similar to the ones of sriov devices. However, instead of setting the mac address to the VF that is moved into the pod namespace, it is the vdpa device that needs to be updated.

Setting a mac address to vdpa devices is supported from kernel 6.12 on.

If I understand correctly, there's no proper way to make IPAM work directly as the vdpa interface would be under the VM, not the host or the pod.

```release-note
Support vhost-vdpa devices for clusters running on kernels newer than 6.12
```
