### PR TITLE
Enhance VF release process with retry logic and error handling

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -543,10 +543,20 @@ func releaseVFWithRetry(args *skel.CmdArgs, deviceID, origIfName string) error {
 		if err == nil {
 			return nil
 		}
+
+		// If the container namespace no longer exists, the kernel has already
+		// moved the VF back to the host namespace. Per the CNI spec, DEL
+		// should succeed when resources are already gone.
+		var nsPathErr ns.NSPathNotExistErr
+		if errors.As(err, &nsPathErr) {
+			log.Printf("ReleaseVF: container netns gone, VF %s (deviceID=%s) assumed restored to host", origIfName, deviceID)
+			return nil
+		}
+
 		lastErr = err
 
 		log.Printf("ReleaseVF attempt %d failed for VF %s (deviceID=%s): %v", attempt, origIfName, deviceID, err)
-		if resetErr := sriov.ResetVF(args, deviceID, origIfName); resetErr != nil {
+		if resetErr := sriov.ResetVF(args, deviceID, origIfName); resetErr == nil || errors.Is(resetErr, ip.ErrLinkNotFound) {
 			log.Printf("Failed best-effort cleanup of VF %s: %v", origIfName, resetErr)
 		}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -527,6 +527,42 @@ func removeOvsPort(ovsDriver *ovsdb.OvsBridgeDriver, portName string) error {
 	return ovsDriver.DeletePort(portName)
 }
 
+func releaseVFWithRetry(args *skel.CmdArgs, deviceID, origIfName string) error {
+	const (
+		maxRetryDuration = 5 * time.Second
+		initialBackoff  = 100 * time.Millisecond
+		maxBackoff      = 1 * time.Second
+	)
+
+	deadline := time.Now().Add(maxRetryDuration)
+	backoff := initialBackoff
+	var lastErr error
+
+	for attempt := 1; ; attempt++ {
+		err := sriov.ReleaseVF(args, deviceID, origIfName)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		log.Printf("ReleaseVF attempt %d failed for VF %s (deviceID=%s): %v", attempt, origIfName, deviceID, err)
+		if resetErr := sriov.ResetVF(args, deviceID, origIfName); resetErr != nil {
+			log.Printf("Failed best-effort cleanup of VF %s: %v", origIfName, resetErr)
+		}
+
+		if time.Now().Add(backoff).After(deadline) {
+			break
+		}
+		time.Sleep(backoff)
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+
+	return fmt.Errorf("failed to release VF %s (deviceID=%s) after retries: %v", origIfName, deviceID, lastErr)
+}
+
 // CmdDel remove handler for deleting container from network
 func CmdDel(args *skel.CmdArgs) error {
 	logCall("DEL", args)
@@ -631,13 +667,7 @@ func CmdDel(args *skel.CmdArgs) error {
 	if sriov.IsOvsHardwareOffloadEnabled(cache.Netconf.DeviceID) {
 		// there is no network interface in case of userspace driver, so OrigIfName is empty
 		if !cache.UserspaceMode {
-			err = sriov.ReleaseVF(args, cache.OrigIfName)
-			if err != nil {
-				// try to reset vf into original state as much as possible in case of error
-				if err := sriov.ResetVF(args, cache.Netconf.DeviceID, cache.OrigIfName); err != nil {
-					log.Printf("Failed best-effort cleanup of VF %s: %v", cache.OrigIfName, err)
-				}
-			}
+			err = releaseVFWithRetry(args, cache.Netconf.DeviceID, cache.OrigIfName)
 		}
 	} else {
 		err = ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -13,10 +13,13 @@
 package sriov
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -368,21 +371,130 @@ func renameLink(curName, newName string) (netlink.Link, error) {
 	return link, nil
 }
 
+func linkByNameIfExists(ifName string) (netlink.Link, bool, error) {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return link, true, nil
+}
+
+func deleteLinkIfExists(ifName string) error {
+	err := ip.DelLinkByName(ifName)
+	if err == nil || err == ip.ErrLinkNotFound {
+		return nil
+	}
+	return err
+}
+
+func isFileExistsErr(err error) bool {
+	return errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EEXIST)
+}
+
+func reconcileExistingTargetInContNetns(hostNs ns.NetNS, currentName, targetName string) error {
+	targetLink, targetFound, err := linkByNameIfExists(targetName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup target interface %s: %v", targetName, err)
+	}
+	if !targetFound {
+		return ip.ErrLinkNotFound
+	}
+
+	// Delete the stale source link first so that a partial failure
+	// (target not yet moved) can be retried cleanly.
+	if err := deleteLinkIfExists(currentName); err != nil {
+		return fmt.Errorf("failed to delete stale source interface %s: %v", currentName, err)
+	}
+
+	// Some kernel versions require the link to be down before moving
+	// between network namespaces.
+	if err := netlink.LinkSetDown(targetLink); err != nil {
+		return fmt.Errorf("failed to set link %s down before netns move: %v", targetName, err)
+	}
+
+	if err := netlink.LinkSetNsFd(targetLink, int(hostNs.Fd())); err != nil {
+		return fmt.Errorf("failed to move existing target interface %s to host netns: %v", targetName, err)
+	}
+
+	return nil
+}
+
 // ReleaseVF release the VF from container namespace into host namespace
-func ReleaseVF(args *skel.CmdArgs, origIfName string) error {
+func ReleaseVF(args *skel.CmdArgs, deviceID, origIfName string) error {
 	hostNs, err := ns.GetCurrentNS()
 	if err != nil {
 		return fmt.Errorf("failed to get host netns: %v", err)
 	}
+	defer func() { _ = hostNs.Close() }()
+
 	contNetns, err := ns.GetNS(args.Netns)
 	if err != nil {
 		return fmt.Errorf("failed to open container netns %q: %v", args.Netns, err)
 	}
+	defer func() { _ = contNetns.Close() }()
+
+	log.Printf("ReleaseVF pre-rename: contNetns=%s hostNetns=%s currentName=%s targetName=%s deviceID=%s",
+		contNetns.Path(), hostNs.Path(), args.IfName, origIfName, deviceID)
 
 	return contNetns.Do(func(_ ns.NetNS) error {
+		if _, found, err := linkByNameIfExists(args.IfName); err != nil {
+			return fmt.Errorf("failed to lookup source interface %s: %v", args.IfName, err)
+		} else if !found {
+			if err := reconcileExistingTargetInContNetns(hostNs, args.IfName, origIfName); err == nil {
+				log.Printf("ReleaseVF source missing: moved existing target to host: contNetns=%s currentName=%s targetName=%s deviceID=%s",
+					contNetns.Path(), args.IfName, origIfName, deviceID)
+				return nil
+			} else if !errors.Is(err, ip.ErrLinkNotFound) {
+				return err
+			}
+
+			hostHasTarget := false
+			if err := hostNs.Do(func(_ ns.NetNS) error {
+				_, foundInHost, err := linkByNameIfExists(origIfName)
+				if err != nil {
+					return err
+				}
+				hostHasTarget = foundInHost
+				return nil
+			}); err != nil {
+				return fmt.Errorf("failed to verify target interface %s in host netns: %v", origIfName, err)
+			}
+
+			if hostHasTarget {
+				// Already restored to host netns by a prior cleanup.
+				return nil
+			}
+
+			// Neither source nor target names are present where expected yet.
+			return ip.ErrLinkNotFound
+		}
+
+		if _, found, err := linkByNameIfExists(origIfName); err != nil {
+			return fmt.Errorf("failed to lookup target interface %s: %v", origIfName, err)
+		} else if found {
+			if err := reconcileExistingTargetInContNetns(hostNs, args.IfName, origIfName); err != nil {
+				return err
+			}
+			log.Printf("ReleaseVF conflict reconciled: moved existing target and removed stale source: contNetns=%s currentName=%s targetName=%s deviceID=%s",
+				contNetns.Path(), args.IfName, origIfName, deviceID)
+			return nil
+		}
+
 		// rename VF device back to its original name
 		linkObj, err := renameLink(args.IfName, origIfName)
 		if err != nil {
+			if isFileExistsErr(err) {
+				if reconcileErr := reconcileExistingTargetInContNetns(hostNs, args.IfName, origIfName); reconcileErr == nil {
+					log.Printf("ReleaseVF idempotent rename conflict: reconciled after EEXIST: contNetns=%s currentName=%s targetName=%s deviceID=%s",
+						contNetns.Path(), args.IfName, origIfName, deviceID)
+					return nil
+				} else if !errors.Is(reconcileErr, ip.ErrLinkNotFound) {
+					return reconcileErr
+				}
+			}
 			return err
 		}
 		// move VF device to host netns
@@ -395,6 +507,19 @@ func ReleaseVF(args *skel.CmdArgs, origIfName string) error {
 
 // ResetVF reset the VF which accidentally moved into default network namespace by a container failure
 func ResetVF(args *skel.CmdArgs, deviceID, origIfName string) error {
+	hostNs, err := ns.GetCurrentNS()
+	if err == nil {
+		defer func() { _ = hostNs.Close() }()
+		log.Printf("ResetVF pre-rename: netns=%s currentName=%s targetName=%s deviceID=%s", hostNs.Path(), args.IfName, origIfName, deviceID)
+	}
+
+	if _, found, err := linkByNameIfExists(origIfName); err != nil {
+		return fmt.Errorf("failed to lookup target interface %s: %v", origIfName, err)
+	} else if found {
+		// The VF is already restored under the expected name.
+		return nil
+	}
+
 	// get smart VF netdevice from PCI
 	vfNetdevices, err := sriovnet.GetNetDevicesFromPci(deviceID)
 	if err != nil {
@@ -409,6 +534,11 @@ func ResetVF(args *skel.CmdArgs, deviceID, origIfName string) error {
 	}
 	_, err = renameLink(vfNetdevices[0], origIfName)
 	if err != nil {
+		if isFileExistsErr(err) {
+			if _, found, lookupErr := linkByNameIfExists(origIfName); lookupErr == nil && found {
+				return nil
+			}
+		}
 		return err
 	}
 

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -432,7 +432,7 @@ func ReleaseVF(args *skel.CmdArgs, deviceID, origIfName string) error {
 
 	contNetns, err := ns.GetNS(args.Netns)
 	if err != nil {
-		return fmt.Errorf("failed to open container netns %q: %v", args.Netns, err)
+		return fmt.Errorf("failed to open container netns %q: %w", args.Netns, err)
 	}
 	defer func() { _ = contNetns.Close() }()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:
Fixes a pod termination issues which has been seen in kubevirt related environments. The CNI DEL path is hardened with retry logic and overall idempotence across various scenarios.

**Special notes for your reviewer**:

**Release note**:

```release-note
Idempotent CNI DEL path
Retry logic on CNI DEL path
```
