### PR TITLE
ci: add DCO sign-off check for pull requests

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,29 @@
+name: DCO check
+on:
+  pull_request:
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          failed=0
+          for sha in $(git rev-list --no-merges "$base"..HEAD); do
+            if ! git log -1 --format='%B' "$sha" | grep -qP '^Signed-off-by: .+ <.+>'; then
+              echo "::error::Commit $sha is missing a DCO Signed-off-by line"
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "All commits must include a Signed-off-by line."
+            echo "Use 'git commit -s' to add it automatically."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that verifies all commits in a PR include a `Signed-off-by` line (DCO)
- Fails with clear error messages pointing to the offending commits and instructions to use `git commit -s`

## Test plan
- [x] Open a PR with a commit missing `Signed-off-by` and verify the check fails
- [x] Open a PR with all commits signed off and verify the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)