### PR TITLE
fix(plugin): honor OvnPort/MAC from CNI args.cni in StdinData

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -84,6 +84,27 @@ func getEnvArgs(envArgsString string) (*EnvArgs, error) {
 	return nil, nil
 }
 
+// applyConfArgsFallback fills mac/ovnPort from netconf.Args.Cni when the
+// CNI_ARGS env did not provide them. multus-cni propagates per-pod cni-args
+// through StdinData (args.cni.<Key>), not via CNI_ARGS, so OvnPort from a
+// pod annotation only reaches us through this path. Keys are case-sensitive
+// and match the EnvArgs struct field names.
+func applyConfArgsFallback(netconf *types.NetConf, mac, ovnPort *string) {
+	if netconf == nil || netconf.Args == nil || netconf.Args.Cni == nil {
+		return
+	}
+	if mac != nil && *mac == "" {
+		if v, ok := netconf.Args.Cni["MAC"]; ok {
+			*mac = v
+		}
+	}
+	if ovnPort != nil && *ovnPort == "" {
+		if v, ok := netconf.Args.Cni["OvnPort"]; ok {
+			*ovnPort = v
+		}
+	}
+}
+
 // IPAddrToHWAddr takes the four octets of IPv4 address (aa.bb.cc.dd, for example) and uses them in creating
 // a MAC address (0A:58:AA:BB:CC:DD).  For IPv6, create a hash from the IPv6 string and use that for MAC Address.
 // Assumption: the caller will ensure that an empty net.IP{} will NOT be passed.
@@ -276,6 +297,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	applyConfArgsFallback(netconf, &mac, &ovnPort)
 
 	var vlanTagNum uint = 0
 	trunks := make([]uint, 0)
@@ -564,6 +586,9 @@ func CmdDel(args *skel.CmdArgs) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	var delMACUnused string
+	applyConfArgsFallback(cache.Netconf, &delMACUnused, &ovnPort)
+
 	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
 	if err != nil {
 		return err
@@ -685,6 +710,9 @@ func CmdCheck(args *skel.CmdArgs) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	var checkMACUnused string
+	applyConfArgsFallback(netconf, &checkMACUnused, &ovnPort)
+
 	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)
 	if err != nil {
 		return err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,6 +42,17 @@ type NetConf struct {
 	SocketFile             string   `json:"socket_file"`
 	LinkStateCheckRetries  int      `json:"link_state_check_retries"`
 	LinkStateCheckInterval int      `json:"link_state_check_interval"`
+
+	// Args carries CNI 0.4.0+ "args" passthrough. Meta-plugins such as
+	// multus-cni inject per-invocation parameters (e.g. ovnPort) here from a
+	// pod's `k8s.v1.cni.cncf.io/networks[].cni-args` annotation. Only the
+	// reserved "cni" sub-key is consulted.
+	Args *PluginArgs `json:"args,omitempty"`
+}
+
+// PluginArgs carries the "args.cni" map from CNI conf StdinData.
+type PluginArgs struct {
+	Cni map[string]string `json:"cni,omitempty"`
 }
 
 // netConfAlias is used to avoid infinite recursion when marshaling NetConf.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a silent integration bug between **ovs-cni** and **multus-cni** that prevents the `ovnPort` feature from working when invoked through the standard multus annotation path.

**Background.** ovs-cni's plugin reads `OvnPort` (and `MAC`) only from the `CNI_ARGS` environment variable via `cnitypes.LoadArgs(args.Args, &EnvArgs{})`. multus-cni, however, takes the `cni-args` map from a pod's `k8s.v1.cni.cncf.io/networks[].cni-args` annotation and injects it into the delegate plugin's **StdinData** under `args.cni.<Key>`, _not_ via `CNI_ARGS`. As a result:

- the veth is added to the bridge,
- `external_ids:iface-id` is **never set**,
- `ovn-controller` never binds the OVN logical switch port to the chassis,
- the pod has no L2/L3 connectivity through OVN.

There is no warning anywhere in the stack: multus passes its own `IgnoreUnknown=1` to delegates, so even if a user tries the lower-case `cni-args.ovnPort` key the unknown-args check is suppressed and the request appears to succeed.

**Fix.** Add an `Args` field to `NetConf` capturing the CNI 0.4.0+ `args.cni` map from StdinData, and have `CmdAdd` / `CmdDel` / `CmdCheck` fall back to it when `CNI_ARGS` did not supply `OvnPort` or `MAC`. `CNI_ARGS` keeps priority, so callers that already pass values via env (e.g. kubevirt virt-launcher) are unaffected. Key names are case-sensitive and match the existing `EnvArgs` struct field names (`OvnPort`, `MAC`).

Patch size: **+39 LOC across 2 files**, no test changes needed (existing tests cover the env-var path).

**Special notes for your reviewer**:

End-to-end verified on a real Neutron + OVN cluster (multus-cni 4.2.4, OVN 24.x, Open vSwitch 3.x):

1. Created Neutron ports on a **geneve tenant** network (`provider:network_type=geneve`) and a **flat provider** network (`provider:network_type=flat`, mapped to `br-ex` via OVN `bridge_mappings`).
2. Two pods attached to each network using the standard annotation:
   ```yaml
   k8s.v1.cni.cncf.io/networks: |
     [{"name":"ovn-tenant","mac":"fa:16:3e:...","ips":["192.168.1.8/24"],
       "cni-args":{"OvnPort":"<neutron-port-uuid>"}}]
   ```
3. **Before this patch** (v0.39.0): veths land on `br-int` with empty `external_ids`, OVN SB `port_binding.chassis=[]`, ping 100 % loss. The fix only worked when an operator manually ran `ovs-vsctl set interface <veth> external_ids:iface-id=<uuid>`.
4. **After this patch**: `external_ids:iface-id` and `ovn-installed=true` show up automatically, OVN SB binds both LSPs to the local chassis (`up=true`), and ping between pods works for both overlay (geneve) and underlay (flat localnet) — 0 % loss, RTT 0.1–7 ms.

The change is intentionally minimal: a `nil`-guarded helper plus three one-line call sites. CNI_ARGS still wins when both paths are present, so downstream consumers like kubevirt are not affected.

**Release note**:

```release-note
Fix `ovnPort` / `MAC` not being honored when passed via the multus-cni
`cni-args` pod annotation. ovs-cni now also reads these values from
`args.cni.<Key>` in the CNI conf StdinData, in addition to the existing
`CNI_ARGS` env var path. CNI_ARGS retains priority.
```
