### PR TITLE
fix(plugin): check trunk id instead of minID in bounds validation

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -96,7 +96,7 @@ func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 		var id uint
 		if item.ID != nil {
 			id = *item.ID
-			if minID > 4096 {
+			if id > 4096 {
 				return nil, errors.New("incorrect trunk id parameter")
 			}
 			vlans[id] = true

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -78,4 +78,10 @@ var _ = Describe("", func() {
 			testSplitVlanIds(trunks, nil, errors.New("incorrect trunk maxID parameter"), false)
 		})
 	})
+	Context("specify trunk with id greater than 4096", func() {
+		trunks := `[ {"id": 15}, {"id": 5000} ]`
+		It("testSplitVlanIds method should throw appropriate error", func() {
+			testSplitVlanIds(trunks, nil, errors.New("incorrect trunk id parameter"), false)
+		})
+	})
 })


### PR DESCRIPTION
The condition was comparing minID against 4096 instead of the actual id value, allowing out-of-range individual trunk IDs to slip through undetected.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
