### PR TITLE
fix(plugin): honor OvnPort/MAC from CNI args.cni in StdinData

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ spec:
 EOF
 ```
 
+Per-pod parameters such as the interface `mac` or an OVN `ovnPort` can be passed
+through the network's `cni-args`; see
+[Per-Pod Arguments](docs/cni-plugin.md#per-pod-arguments-mac--ovnport) for details.
+
 Such pod should contain default `eth0` interface connected to default Kubernetes network and also `net1` connected to the bridge.
 
 ```shell

--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -62,6 +62,16 @@ Another example with a port which has an interface of type system:
 * `configuration_path` (optional): configuration file containing ovsdb
   socket file path, etc.
 
+The following are *per-invocation* arguments rather than static network
+configuration. They are not set in the `NetworkAttachmentDefinition` `config`
+body, but passed per pod through CNI args (see
+[Per-Pod Arguments](#per-pod-arguments-mac--ovnport)):
+
+* `mac` (string, optional): MAC address to assign to the container interface.
+* `ovnPort` (string, optional): value written to the OVS interface's
+  `external_ids:iface-id`, used to bind the port to an OVN logical switch port.
+  When set, `bridge` may be omitted (it is derived from the port).
+
 
 _*Note:* if `deviceID` is provided, then it is possible to omit `bridge` argument. Bridge will be automatically selected by the CNI plugin by following
 the chain: Virtual Function PCI address (provided in `deviceID` argument) > Physical Function > Bond interface 
@@ -105,6 +115,68 @@ The `socket_file` consist of socket type and socket detail like these.
 If no socket type is specified, it is assumed to be a unix domain socket, for backwards compatibility.
 
 The `link_state_check_interval` is in milliseconds.
+
+## Per-Pod Arguments (`mac` / `ovnPort`)
+
+Some parameters are specific to a single pod attachment rather than to the
+network as a whole, and therefore cannot live in the shared
+`NetworkAttachmentDefinition` `config`. ovs-cni accepts two such per-invocation
+arguments:
+
+* `mac` — MAC address for the container interface.
+* `ovnPort` — value stored in the OVS interface's `external_ids:iface-id`,
+  which binds the port to a pre-created OVN logical switch port.
+
+They can be supplied through either of the two standard CNI mechanisms:
+
+### 1. `CNI_ARGS` environment variable
+
+When invoking the plugin directly, pass them as `CNI_ARGS`:
+
+```shell
+CNI_ARGS="mac=0a:58:0a:f4:00:07;ovnPort=my-logical-port" ...
+```
+
+### 2. Multus network annotation (`cni-args`)
+
+When Multus is in use, `CNI_ARGS` is not available per network. Instead, attach
+the parameters to the individual network selection using the `cni-args` field of
+the `k8s.v1.cni.cncf.io/networks` annotation. Multus forwards `cni-args` to the
+delegate plugin inside the CNI config's `args.cni` object, and ovs-cni reads
+`mac` / `ovnPort` from there:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: samplepod
+  annotations:
+    k8s.v1.cni.cncf.io/networks: |
+      [
+        {
+          "name": "ovs-conf",
+          "cni-args": {
+            "mac": "0a:58:0a:f4:00:07",
+            "ovnPort": "my-logical-port"
+          }
+        }
+      ]
+spec:
+  containers:
+  - name: samplepod
+    command: ["/bin/sh", "-c", "sleep 99999"]
+    image: alpine
+```
+
+This is the path that lets a per-pod `ovnPort` (for example, one allocated by an
+external OVN/Neutron controller and written onto the pod) actually reach the OVS
+port, which is not possible through `CNI_ARGS` alone under Multus.
+
+Key matching for these arguments is **case-insensitive** (`ovnPort`, `ovnport`
+and `OvnPort` are all accepted), so a casing difference in a hand-written
+annotation does not silently drop the value. Entries under
+`args.cni` that are not JSON strings, or whose keys ovs-cni does not recognize,
+are ignored, so unrelated `cni-args` used by other plugins do not interfere.
 
 ## Manual Testing
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -16,11 +16,13 @@ package common
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/j-keck/arping"
@@ -60,6 +62,60 @@ func GetEnvArgs(envArgsString string) (*types.EnvArgs, error) {
 		return &e, nil
 	}
 	return nil, nil
+}
+
+// ApplyConfArgsFallback fills mac/ovnPort from netconf.Args.Cni when the
+// CNI_ARGS env did not provide them. multus-cni propagates per-pod cni-args
+// through StdinData (args.cni.<Key>), not via CNI_ARGS, so OvnPort from a
+// pod annotation only reaches us through this path. Key matching is
+// case-insensitive ("OvnPort", "ovnPort", "ovnport" all work). Either
+// pointer may be nil if the caller does not care about that value. Values
+// that are not JSON strings (e.g. numbers, arrays) are silently skipped so
+// unrelated entries under args.cni do not break the lookup.
+func ApplyConfArgsFallback(netconf *types.NetConf, mac, ovnPort *string) {
+	if netconf == nil || netconf.Args == nil || netconf.Args.Cni == nil {
+		return
+	}
+	wantMAC := mac != nil && *mac == ""
+	wantOvnPort := ovnPort != nil && *ovnPort == ""
+	if !wantMAC && !wantOvnPort {
+		return
+	}
+	for k, raw := range netconf.Args.Cni {
+		switch strings.ToLower(k) {
+		case "mac":
+			if wantMAC {
+				if v, ok := decodeArgString(raw); ok {
+					*mac = v
+					wantMAC = false
+				}
+			}
+		case "ovnport":
+			if wantOvnPort {
+				if v, ok := decodeArgString(raw); ok {
+					*ovnPort = v
+					wantOvnPort = false
+				}
+			}
+		}
+		if !wantMAC && !wantOvnPort {
+			return
+		}
+	}
+}
+
+// decodeArgString decodes a JSON-encoded args.cni value as a string. Non-string
+// types (numbers, arrays, objects) return ok=false rather than an error, so a
+// foreign entry like `"ips": ["1.2.3.4/24"]` is ignored without aborting.
+func decodeArgString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", false
+	}
+	return s, true
 }
 
 // IsOvsHardwareOffloadEnabled when device id is set, then ovs hardware offload

--- a/pkg/sriov/plugin.go
+++ b/pkg/sriov/plugin.go
@@ -43,6 +43,7 @@ func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
 		ovnPort = string(envArgs.OvnPort)
 		contPodUid = string(envArgs.K8S_POD_UID)
 	}
+	common.ApplyConfArgsFallback(netconf, &mac, &ovnPort)
 
 	portCfg, err := common.ParseOvsPortConfig(netconf)
 	if err != nil {
@@ -166,6 +167,7 @@ func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	common.ApplyConfArgsFallback(cache.Netconf, nil, &ovnPort)
 	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
 	if err != nil {
 		return err
@@ -246,6 +248,7 @@ func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	common.ApplyConfArgsFallback(netconf, nil, &ovnPort)
 
 	// Discover bridge name using SR-IOV specific logic
 	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,20 @@ type NetConf struct {
 	LinkStateCheckRetries  int            `json:"link_state_check_retries"`
 	LinkStateCheckInterval int            `json:"link_state_check_interval"`
 	RuntimeConfig          *RuntimeConfig `json:"runtimeConfig,omitempty"`
+
+	// Args carries CNI 0.4.0+ "args" passthrough. Meta-plugins such as
+	// multus-cni inject per-invocation parameters (e.g. ovnPort) here from a
+	// pod's `k8s.v1.cni.cncf.io/networks[].cni-args` annotation. Only the
+	// reserved "cni" sub-key is consulted.
+	Args *PluginArgs `json:"args,omitempty"`
+}
+
+// PluginArgs carries the "args.cni" map from CNI conf StdinData. Values are
+// kept as json.RawMessage rather than string so foreign entries (e.g. the
+// IPAM-style `ips` array) coexisting under args.cni do not break NetConf
+// unmarshal — the fallback decodes only the keys it consumes.
+type PluginArgs struct {
+	Cni map[string]json.RawMessage `json:"cni,omitempty"`
 }
 
 // netConfAlias is used to avoid infinite recursion when marshaling NetConf.

--- a/pkg/vdpa/plugin.go
+++ b/pkg/vdpa/plugin.go
@@ -43,6 +43,7 @@ func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
 		ovnPort = string(envArgs.OvnPort)
 		contPodUid = string(envArgs.K8S_POD_UID)
 	}
+	common.ApplyConfArgsFallback(netconf, &mac, &ovnPort)
 
 	portCfg, err := common.ParseOvsPortConfig(netconf)
 	if err != nil {
@@ -136,6 +137,7 @@ func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	common.ApplyConfArgsFallback(cache.Netconf, nil, &ovnPort)
 	ovsDriver, err := ovsdb.NewOvsDriver(cache.Netconf.SocketFile)
 	if err != nil {
 		return err
@@ -188,6 +190,7 @@ func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	common.ApplyConfArgsFallback(netconf, nil, &ovnPort)
 
 	// Discover bridge name using SR-IOV specific logic
 	ovsDriver, err := ovsdb.NewOvsDriver(netconf.SocketFile)

--- a/pkg/veth/plugin.go
+++ b/pkg/veth/plugin.go
@@ -44,6 +44,7 @@ func CmdAdd(args *skel.CmdArgs, netconf *types.NetConf) error {
 		ovnPort = string(envArgs.OvnPort)
 		contPodUid = string(envArgs.K8S_POD_UID)
 	}
+	common.ApplyConfArgsFallback(netconf, &mac, &ovnPort)
 
 	portCfg, err := common.ParseOvsPortConfig(netconf)
 	if err != nil {
@@ -140,6 +141,7 @@ func CmdDel(args *skel.CmdArgs, cache *types.CachedNetConf) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	common.ApplyConfArgsFallback(cache.Netconf, nil, &ovnPort)
 
 	bridgeName, err := common.GetBridgeName(cache.Netconf.BrName, ovnPort)
 	if err != nil {
@@ -204,6 +206,7 @@ func CmdCheck(args *skel.CmdArgs, netconf *types.NetConf) error {
 	if envArgs != nil {
 		ovnPort = string(envArgs.OvnPort)
 	}
+	common.ApplyConfArgsFallback(netconf, nil, &ovnPort)
 
 	// Discover bridge name
 	bridgeName, err := common.GetBridgeName(netconf.BrName, ovnPort)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a silent integration bug between **ovs-cni** and **multus-cni** that prevents the `ovnPort` feature from working when invoked through the standard multus annotation path.

**Background.** ovs-cni's plugin reads `OvnPort` (and `MAC`) only from the `CNI_ARGS` environment variable via `cnitypes.LoadArgs(args.Args, &EnvArgs{})`. multus-cni, however, takes the `cni-args` map from a pod's `k8s.v1.cni.cncf.io/networks[].cni-args` annotation and injects it into the delegate plugin's **StdinData** under `args.cni.<Key>`, _not_ via `CNI_ARGS`. As a result:

- the veth is added to the bridge,
- `external_ids:iface-id` is **never set**,
- `ovn-controller` never binds the OVN logical switch port to the chassis,
- the pod has no L2/L3 connectivity through OVN.

There is no warning anywhere in the stack: multus passes its own `IgnoreUnknown=1` to delegates, so even if a user tries the lower-case `cni-args.ovnPort` key the unknown-args check is suppressed and the request appears to succeed.

**Fix.** Add an `Args` field to `NetConf` capturing the CNI 0.4.0+ `args.cni` map from StdinData, and have the veth/sriov/vdpa `CmdAdd` / `CmdDel` / `CmdCheck` paths fall back to it (via a new `common.ApplyConfArgsFallback` helper) when `CNI_ARGS` did not supply `OvnPort` or `MAC`. `CNI_ARGS` keeps priority, so callers that already pass values via env (e.g. kubevirt virt-launcher) are unaffected.

**This PR supersedes #529.** That PR was filed before the vhost_vdpa refactor (#427) split the plugin into per-backend packages; this rebased version applies the same fix in all three backends and addresses the automated review feedback on #529:

* `PluginArgs.Cni` is `map[string]json.RawMessage` instead of `map[string]string`, so an unrelated array/object entry under `args.cni` (for example the IPAM-style `ips` array) does not break `NetConf` unmarshal — values are decoded lazily only for the keys the fallback consumes.
* Key matching is **case-insensitive** — pod annotations written as `ovnPort`, `OvnPort`, or `ovnport` all resolve.
* The fallback helper accepts `nil` pointers for either output, so `CmdDel` / `CmdCheck` (which only care about `ovnPort`) need no dummy variables.

**Special notes for your reviewer**:

End-to-end verified on a real Neutron + OVN cluster (multus-cni 4.2.4, OVN 24.x, Open vSwitch 3.x):

1. Created Neutron ports on a **geneve tenant** network (`provider:network_type=geneve`) and a **flat provider** network (`provider:network_type=flat`, mapped to `br-ex` via OVN `bridge_mappings`).
2. Two pods attached to each network using the standard annotation:
   ```yaml
   k8s.v1.cni.cncf.io/networks: |
     [{"name":"ovn-tenant","mac":"fa:16:3e:...","ips":["192.168.1.8/24"],
       "cni-args":{"OvnPort":"<neutron-port-uuid>"}}]
   ```
3. **Before this patch** (v0.39.0): veths land on `br-int` with empty `external_ids`, OVN SB `port_binding.chassis=[]`, ping 100 % loss. The fix only worked when an operator manually ran `ovs-vsctl set interface <veth> external_ids:iface-id=<uuid>`.
4. **After this patch**: `external_ids:iface-id` and `ovn-installed=true` show up automatically, OVN SB binds both LSPs to the local chassis (`up=true`), and ping between pods works for both overlay (geneve) and underlay (flat localnet) — 0 % loss, RTT 0.1–7 ms.

The change is intentionally minimal: a `nil`-guarded helper plus nine one-line call sites (three backends x ADD/DEL/CHECK). CNI_ARGS still wins when both paths are present, so downstream consumers like kubevirt are not affected.

**Release note**:

```release-note
Fix `ovnPort` / `MAC` not being honored when passed via the multus-cni
`cni-args` pod annotation. ovs-cni now also reads these values from
`args.cni.<Key>` in the CNI conf StdinData, in addition to the existing
`CNI_ARGS` env var path. Matching is case-insensitive; CNI_ARGS retains
priority.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for CNI 0.4.0+ per-invocation arguments, enabling automatic fallback for network parameters like `mac` and `ovnPort` when not provided via environment/config.

* **Improvements**
  * Improved consistency of `mac`/`ovnPort` initialization across veth, SR-IOV, and vDPA workflows, including DEL/CHECK paths.
  * Updated documentation to describe how to supply `mac` and `ovnPort` via `cni-args`/`CNI_ARGS`, including case-insensitive matching and handling of unrecognized/invalid entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->