### PR TITLE
common: VLAN ID verification fixes

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -97,7 +97,7 @@ func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 		var id uint
 		if item.ID != nil {
 			id = *item.ID
-			if minID > highestVlanID {
+			if id > highestVlanID {
 				return nil, errors.New("incorrect trunk id parameter")
 			}
 			vlans[id] = true

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -42,6 +42,7 @@ import (
 const (
 	portTypeAccess = "access"
 	portTypeTrunk  = "trunk"
+	highestVlanID  = 4095
 )
 
 type OvsPortConfig struct {
@@ -75,13 +76,13 @@ func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 		var maxID uint = 0
 		if item.MinID != nil {
 			minID = *item.MinID
-			if minID > 4096 {
+			if minID > highestVlanID {
 				return nil, errors.New("incorrect trunk minID parameter")
 			}
 		}
 		if item.MaxID != nil {
 			maxID = *item.MaxID
-			if maxID > 4096 {
+			if maxID > highestVlanID {
 				return nil, errors.New("incorrect trunk maxID parameter")
 			}
 			if maxID < minID {
@@ -96,7 +97,7 @@ func SplitVlanIds(trunks []*types.Trunk) ([]uint, error) {
 		var id uint
 		if item.ID != nil {
 			id = *item.ID
-			if minID > 4096 {
+			if minID > highestVlanID {
 				return nil, errors.New("incorrect trunk id parameter")
 			}
 			vlans[id] = true

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -78,4 +78,10 @@ var _ = Describe("", func() {
 			testSplitVlanIds(trunks, nil, errors.New("incorrect trunk maxID parameter"), false)
 		})
 	})
+	Context("specify trunk with ID greater than 4095", func() {
+		trunks := `[ {"id": 15}, {"id": 4096}, {"id": 1} ]`
+		It("testSplitVlanIds method should throw appropriate error", func() {
+			testSplitVlanIds(trunks, []uint{}, errors.New("incorrect trunk id parameter"), false)
+		})
+	})
 })

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -72,8 +72,8 @@ var _ = Describe("", func() {
 			testSplitVlanIds(trunks, nil, errors.New("minID is greater than maxID in trunk parameter"), false)
 		})
 	})
-	Context("specify trunk with maxID greater than 4096", func() {
-		trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 1, "maxID": 5000} ]`
+	Context("specify trunk with maxID greater than 4095", func() {
+		trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 1, "maxID": 4096} ]`
 		It("testSplitVlanIds method should throw appropriate error", func() {
 			testSplitVlanIds(trunks, nil, errors.New("incorrect trunk maxID parameter"), false)
 		})


### PR DESCRIPTION
Maximum allowed vlan tag should be 4095, not 4096, which exceeds the maximum value that a 12-bit long unsigned int can hold.
Also, if vlan ID is provided, not max/min limits, it should be the ID that is checked, not the minimum ID.

**What this PR does / why we need it**:
- Fixes https://github.com/k8snetworkplumbingwg/ovs-cni/issues/510
- Fixes https://github.com/k8snetworkplumbingwg/ovs-cni/issues/511

**Special notes for your reviewer**:
Even if ovs FAQ on vlan points out that [vlan ID 4095 is reserved](https://github.com/openvswitch/ovs/blob/b15de27f6467824561d65d0b0f10c881a2becddd/Documentation/faq/vlan.rst?plain=1#L75-L76), I could not find any significant evidence in the ovs source code that 4095 is treated differently or that users are kept away from configuring it.

**Release note**:
<!--  Write your release note:

```release-note
Maximum allowed vlan ID is now limited to 4095
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected VLAN and trunk identifier validation to enforce the maximum supported value of 4095.
  * Values equal to 4096 are now consistently rejected with the existing validation error behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->